### PR TITLE
Rewrite the tool to make it more flexible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: rust
+
+sudo: false
+
+notifications:
+    email:
+        on_success: never
+        on_failure: change
+
+rust:
+    - nightly
+
+cache: cargo
+
+script:
+- cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "bootimage"
-version = "0.2.0-alpha-006"
+version = "0.2.0"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,10 +1,30 @@
 [[package]]
+name = "backtrace"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bootimage"
 version = "0.2.0-alpha-006"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "curl 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lapp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "xmas-elf 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -15,8 +35,20 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cargo_metadata"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
-version = "1.0.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -25,98 +57,67 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "curl"
-version = "0.4.11"
+name = "dtoa"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "error-chain"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "curl-sys 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "schannel 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "curl-sys"
+name = "itoa"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "lapp"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lazy_static"
-version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.36"
+version = "0.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "libz-sys"
-version = "1.0.18"
+name = "num-traits"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.24"
+name = "quote"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.9"
+name = "rustc-demangle"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "schannel"
-version = "0.1.10"
+name = "semver"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
@@ -124,13 +125,44 @@ version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "socket2"
-version = "0.3.1"
+name = "serde_derive"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.12.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -142,13 +174,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
+name = "unicode-xid"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -159,11 +186,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -189,27 +211,30 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
+"checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
-"checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
+"checksum cargo_metadata 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b5caae26de3704081ef638f87f05a6891b04f2b7d5ce9429a3de21095528ae22"
+"checksum cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2b4911e4bdcb4100c7680e7e854ff38e23f1b34d4d9e079efae3da2801341ffc"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum curl 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b70fd6394677d3c0e239ff4be6f2b3176e171ffd1c23ffdc541e78dea2b8bb5e"
-"checksum curl-sys 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f46e49c7125131f5afaded06944d6888b55cbdf8eba05dae73c954019b907961"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lapp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44758669f6f88b6dddac3f833f234d5128530108b5738932a166eb69660faea8"
-"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
-"checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
-"checksum libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "87f737ad6cc6fd6eefe3d9dc5412f1573865bded441300904d2f42269e140f16"
-"checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-"checksum openssl-sys 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "14ba54ac7d5a4eabd1d5f2c1fdeb7e7c14debfa669d94b983d01b465e767ba9e"
-"checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
-"checksum schannel 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "acece75e0f987c48863a6c792ec8b7d6c4177d4a027f8ccc72f849794f437016"
+"checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
+"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
+"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
+"checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
+"checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
+"checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"
-"checksum socket2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a76b792959eba82f021c9028c8ecb6396f085268d6d46af2ed96a829cc758d7c"
+"checksum serde_derive 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "90f1f8f7784452461db5b73dc5097c18f21011fbcc6d1178f1897bfa8e1cb4bd"
+"checksum serde_derive_internals 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f9525ada08124ee1a9b8b1e6f3bf035ffff6fc0c96d56ddda98d4506d3533e4"
+"checksum serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "5c508584d9913df116b91505eec55610a2f5b16e9ed793c46e4d0152872b3e74"
+"checksum syn 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)" = "8c5bc2d6ff27891209efa5f63e9de78648d7801f085e4653701a692ce938d6fd"
 "checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
-"checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum xmas-elf 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e7f5dde2a8bc9d05c0782c0c13ccd72bd3dc6e6bc03a205c8bb3b45257d08a41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/phil-opp/bootimage"
 
 [dependencies]
 byteorder = "1.2.1"
-curl = "0.4.11"
-lapp = "0.3.1"
 toml = "0.4.5"
 xmas-elf = "0.6.1"
+cargo_metadata = "0.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 description = "Tool to create a bootable OS image from a kernel binary."
 license = "MIT/Apache-2.0"
 name = "bootimage"
-version = "0.2.0-alpha-006"
+version = "0.2.0"
 repository = "https://github.com/phil-opp/bootimage"
 
 [dependencies]

--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,7 @@ Configuration is done through a through a `[package.metadata.bootimage]` table i
     name = "bootloader"             # The bootloader crate name
     version = ""                    # The bootloader version that should be used
     git = ""                        # Use the bootloader from this git repository
+    branch = ""                     # The git branch to use (defaults to master)
     path = ""                       # Use the bootloader from this local path
     precompiled = false             # Whether the bootloader crate is precompiled
     target = "x86_64-bootloader"    # Target triple for compiling the bootloader

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,47 @@
+# bootimage
+
+Creates a bootable disk image from a Rust OS kernel.
+
+## Installation
+
+```
+> cargo install bootimage
+```
+
+## Usage
+
+To build the kernel project and create a bootable disk image from it, run:
+
+```
+> bootimage build --target your_custom_target [other_args]
+```
+
+The command will invoke `xargo build`, forwarding all specified options. Then it will download and build a bootloader, by default the [rust-osdev/bootloader](https://rust-osdev.github.com/rust-osdev/bootloader). Finally, it combines the kernel and the bootloader into a bootable disk image.
+
+## Configuration
+
+Configuration is done through a through a `[package.metadata.bootimage]` table in the `Cargo.toml`. The following options are available:
+
+```toml
+    [package.metadata.bootimage]
+    default-target = ""         # This target is used if no `--target` is passed
+    output = "bootimage.bin"    # The output file name
+
+    [package.metadata.bootimage.bootloader]
+    name = "bootloader"             # The bootloader crate name
+    version = ""                    # The bootloader version that should be used
+    git = ""                        # Use the bootloader from this git repository
+    path = ""                       # Use the bootloader from this local path
+    precompiled = false             # Whether the bootloader crate is precompiled
+    target = "x86_64-bootloader"    # Target triple for compiling the bootloader
+```
+
+If no `[package.metadata.bootimage.bootloader]` sub-table is specified, it defaults to:
+
+```toml
+name = "bootloader_precompiled"
+precompiled = true
+```
+
+## License
+Dual-licensed under MIT or the Apache License (Version 2.0).

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,68 @@
+use std::{env, mem};
+use std::path::PathBuf;
+
+const DEFAULT_OUTPUT: &str = "bootimage.bin";
+
+pub fn args() -> Args {
+    let mut args: Vec<_> = env::args().skip(1).collect();
+
+    let mut manifest_path: Option<PathBuf> = None;
+    let mut target: Option<String> = None;
+    let mut release: Option<bool> = None;
+    let mut output: Option<PathBuf> = None;
+    {
+        fn set<T>(arg: &mut Option<T>, value: Option<T>) {
+            let previous = mem::replace(arg, value);
+            assert!(previous.is_none(), "multiple arguments of same type provided")
+        };
+
+        let mut arg_iter = args.iter_mut();
+        while let Some(arg) = arg_iter.next() {
+            match arg.as_ref() {
+                "--target" => {
+                    set(&mut target, arg_iter.next().map(|s| s.clone()));
+                }
+                _ if arg.starts_with("--target=") => {
+                    set(&mut target, Some(String::from(arg.trim_left_matches("--target="))));
+                }
+                "--manifest-path" => {
+                    set(&mut manifest_path, arg_iter.next().map(|p| PathBuf::from(&p)));
+                }
+                _ if arg.starts_with("--manifest-path=") => {
+                    let path = PathBuf::from(arg.trim_left_matches("--manifest-path="));
+                    set(&mut manifest_path, Some(path));
+                }
+                "--release" => set(&mut release, Some(true)),
+                "--output" => {
+                    // remove from arg list
+                    mem::replace(arg, String::new());
+                    let value = arg_iter.next().map(|val| mem::replace(val, String::new()));
+                    set(&mut output, value.map(PathBuf::from));
+                },
+                _ => {},
+            }
+        }
+    }
+
+    Args {
+        all_cargo: args,
+        target,
+        manifest_path,
+        release: release.unwrap_or(false),
+        output: output.unwrap_or(PathBuf::from(DEFAULT_OUTPUT)),
+    }
+}
+
+pub struct Args {
+    /// All arguments that are passed to cargo.
+    pub all_cargo: Vec<String>,
+    /// The manifest path (also present in `all_cargo`).
+    pub manifest_path: Option<PathBuf>,
+    /// The target triple (also present in `all_cargo`).
+    pub target: Option<String>,
+    /// The release flag (also present in `all_cargo`).
+    pub release: bool,
+    /// The output file name (not passed to cargo)
+    pub output: PathBuf,
+}
+

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,15 +1,12 @@
 use std::{env, mem};
 use std::path::PathBuf;
 
-const DEFAULT_OUTPUT: &str = "bootimage.bin";
-
 pub fn parse_args() -> Args {
     let mut args: Vec<_> = env::args().skip(1).collect();
 
     let mut manifest_path: Option<PathBuf> = None;
     let mut target: Option<String> = None;
     let mut release: Option<bool> = None;
-    let mut output: Option<PathBuf> = None;
     {
         fn set<T>(arg: &mut Option<T>, value: Option<T>) {
             let previous = mem::replace(arg, value);
@@ -33,12 +30,6 @@ pub fn parse_args() -> Args {
                     set(&mut manifest_path, Some(path));
                 }
                 "--release" => set(&mut release, Some(true)),
-                "--output" => {
-                    // remove from arg list
-                    mem::replace(arg, String::new());
-                    let value = arg_iter.next().map(|val| mem::replace(val, String::new()));
-                    set(&mut output, value.map(PathBuf::from));
-                },
                 _ => {},
             }
         }
@@ -49,7 +40,6 @@ pub fn parse_args() -> Args {
         target,
         manifest_path,
         release: release.unwrap_or(false),
-        output: output.unwrap_or(PathBuf::from(DEFAULT_OUTPUT)),
     }
 }
 
@@ -62,8 +52,6 @@ pub struct Args {
     target: Option<String>,
     /// The release flag (also present in `all_cargo`).
     release: bool,
-    /// The output file name (not passed to cargo)
-    pub output: PathBuf,
 }
 
 impl Args {

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 const DEFAULT_OUTPUT: &str = "bootimage.bin";
 
-pub fn args() -> Args {
+pub fn parse_args() -> Args {
     let mut args: Vec<_> = env::args().skip(1).collect();
 
     let mut manifest_path: Option<PathBuf> = None;
@@ -57,12 +57,33 @@ pub struct Args {
     /// All arguments that are passed to cargo.
     pub all_cargo: Vec<String>,
     /// The manifest path (also present in `all_cargo`).
-    pub manifest_path: Option<PathBuf>,
+    manifest_path: Option<PathBuf>,
     /// The target triple (also present in `all_cargo`).
-    pub target: Option<String>,
+    target: Option<String>,
     /// The release flag (also present in `all_cargo`).
-    pub release: bool,
+    release: bool,
     /// The output file name (not passed to cargo)
     pub output: PathBuf,
 }
 
+impl Args {
+    pub fn manifest_path(&self) -> &Option<PathBuf> {
+        &self.manifest_path
+    }
+
+    pub fn target(&self) -> &Option<String> {
+        &self.target
+    }
+
+    pub fn release(&self) -> bool {
+        self.release
+    }
+
+
+    pub fn set_target(&mut self, target: String) {
+        assert!(self.target.is_none());
+        self.target = Some(target.clone());
+        self.all_cargo.push("--target".into());
+        self.all_cargo.push(target);
+    }
+}

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,239 @@
+use std::fs::{self, File};
+use std::{env, process, io};
+use std::path::{Path, PathBuf};
+use byteorder::{ByteOrder, LittleEndian};
+use args::{self, Args};
+use config::{self, Config};
+use cargo_metadata::{self, Metadata as CargoMetadata, Package as CrateMetadata};
+use Error;
+use xmas_elf;
+
+const BLOCK_SIZE: usize = 512;
+type KernelInfoBlock = [u8; BLOCK_SIZE];
+
+pub(crate) fn build(mut args: Args) -> Result<(), Error> {
+    let metadata = read_cargo_metadata(&args)?;
+    let crate_root = PathBuf::from(&metadata.workspace_root);
+    let manifest_path = args.manifest_path().as_ref().map(Clone::clone).unwrap_or({
+        let mut path = crate_root.clone();
+        path.push("Cargo.toml");
+        path
+    });
+    let config = config::read_config(manifest_path)?;
+
+    if args.target().is_none() {
+        if let Some(ref target) = config.default_target {
+            args.set_target(target.clone());
+        }
+    }
+
+    let (kernel, out_dir) = build_kernel(&args, &config, &metadata)?;
+
+    let kernel_size = kernel.metadata()?.len();
+    let kernel_info_block = create_kernel_info_block(kernel_size);
+
+    let bootloader = build_bootloader(&out_dir, &config)?;
+
+    create_disk_image(&config, kernel, kernel_info_block, &bootloader)?;
+
+    Ok(())
+}
+
+fn read_cargo_metadata(args: &Args) -> Result<CargoMetadata, cargo_metadata::Error> {
+    cargo_metadata::metadata(args.manifest_path().as_ref().map(PathBuf::as_path))
+}
+
+fn build_kernel(args: &args::Args, config: &Config, metadata: &CargoMetadata) -> Result<(File, PathBuf), Error> {
+    let crate_ = metadata.packages.iter()
+        .find(|p| Path::new(&p.manifest_path) == config.manifest_path)
+        .expect("Could not read crate name from cargo metadata");
+    let crate_name = &crate_.name;
+
+    let target_dir = PathBuf::from(&metadata.target_directory);
+
+    // compile kernel
+    println!("Building kernel");
+    let exit_status = run_xargo_build(&env::current_dir()?, &args.all_cargo)?;
+    if !exit_status.success() { process::exit(1) }
+
+    let mut out_dir = target_dir;
+    if let &Some(ref target) = args.target() {
+        out_dir.push(target);
+    }
+    if args.release() {
+        out_dir.push("release");
+    } else {
+        out_dir.push("debug");
+    }
+
+    let mut kernel_path = out_dir.clone();
+    kernel_path.push(crate_name);
+    let kernel = File::open(kernel_path)?;
+    Ok((kernel, out_dir))
+}
+
+fn run_xargo_build(pwd: &Path, args: &[String]) -> io::Result<process::ExitStatus> {
+    let mut command = process::Command::new("xargo");
+    command.arg("build");
+    command.current_dir(pwd).env("RUST_TARGET_PATH", pwd);
+    command.args(args);
+    command.status()
+}
+
+fn create_kernel_info_block(kernel_size: u64) -> KernelInfoBlock {
+    let kernel_size = if kernel_size <= u64::from(u32::max_value()) {
+        kernel_size as u32
+    } else {
+        panic!("Kernel can't be loaded by BIOS bootloader because is too big")
+    };
+
+    let mut kernel_info_block = [0u8; BLOCK_SIZE];
+    LittleEndian::write_u32(&mut kernel_info_block[0..4], kernel_size);
+
+    kernel_info_block
+}
+
+fn download_bootloader(out_dir: &Path, config: &Config) -> Result<CrateMetadata, Error> {
+    use std::io::Write;
+
+    let bootloader_dir = {
+        let mut dir = PathBuf::from(out_dir);
+        dir.push("bootloader");
+        dir
+    };
+
+    let cargo_toml = {
+        let mut dir = bootloader_dir.clone();
+        dir.push("Cargo.toml");
+        dir
+    };
+    let src_lib = {
+        let mut dir = bootloader_dir.clone();
+        dir.push("src");
+        fs::create_dir_all(dir.as_path())?;
+        dir.push("lib.rs");
+        dir
+    };
+
+    {
+        let mut cargo_toml_file = File::create(&cargo_toml)?;
+        cargo_toml_file.write_all(r#"
+            [package]
+            authors = ["author@example.com>"]
+            name = "bootloader_download_helper"
+            version = "0.0.0"
+
+        "#.as_bytes())?;
+        cargo_toml_file.write_all(format!(r#"
+            [dependencies.{}]
+        "#, config.bootloader.name).as_bytes())?;
+        if let &Some(ref version) = &config.bootloader.version {
+            cargo_toml_file.write_all(format!(r#"
+                    version = "{}"
+            "#, version).as_bytes())?;
+        }
+        if let &Some(ref git) = &config.bootloader.git {
+            cargo_toml_file.write_all(format!(r#"
+                    git = "{}"
+            "#, git).as_bytes())?;
+        }
+        if let &Some(ref path) = &config.bootloader.path {
+            cargo_toml_file.write_all(format!(r#"
+                    path = "{}"
+            "#, path.display()).as_bytes())?;
+        }
+
+        File::create(src_lib)?.write_all(r#"
+            #![no_std]
+        "#.as_bytes())?;
+    }
+
+    let mut command = process::Command::new("cargo");
+    command.arg("fetch");
+    command.current_dir(bootloader_dir);
+    assert!(command.status()?.success(), "Bootloader download failed.");
+
+    let metadata = cargo_metadata::metadata_deps(Some(&cargo_toml), true)?;
+    let bootloader = metadata.packages.iter().find(|p| p.name == config.bootloader.name)
+            .expect(&format!("Could not find crate named “{}”", config.bootloader.name));
+
+    Ok(bootloader.clone())
+}
+
+fn build_bootloader(out_dir: &Path, config: &Config) -> Result<Box<[u8]>, Error> {
+    use std::io::Read;
+
+    let bootloader_metadata = download_bootloader(out_dir, config)?;
+    let bootloader_dir = Path::new(&bootloader_metadata.manifest_path).parent().unwrap();
+
+
+    let bootloader_elf_path = if !config.bootloader.precompiled {
+        let args = &[
+            String::from("--target"),
+            config.bootloader.target.clone(),
+            String::from("--release"),
+        ];
+
+        println!("Building bootloader");
+        let exit_status = run_xargo_build(bootloader_dir, args)?;
+        if !exit_status.success() { process::exit(1) }
+
+        let mut bootloader_elf_path = bootloader_dir.to_path_buf();
+        bootloader_elf_path.push("target");
+        bootloader_elf_path.push(&config.bootloader.target);
+        bootloader_elf_path.push("release");
+        bootloader_elf_path.push("bootloader");
+        bootloader_elf_path
+    } else {
+        let mut bootloader_elf_path = bootloader_dir.to_path_buf();
+        bootloader_elf_path.push("bootloader");
+        bootloader_elf_path
+    };
+
+    let mut bootloader_elf_bytes = Vec::new();
+    let mut bootloader = File::open(&bootloader_elf_path).map_err(|err| {
+        Error::Bootloader(format!("Could not open bootloader at {}",
+            bootloader_elf_path.display()), err)
+    })?;
+    bootloader.read_to_end(&mut bootloader_elf_bytes)?;
+
+    // copy bootloader section of ELF file to bootloader_path
+    let elf_file = xmas_elf::ElfFile::new(&bootloader_elf_bytes).unwrap();
+    xmas_elf::header::sanity_check(&elf_file).unwrap();
+    let bootloader_section = elf_file.find_section_by_name(".bootloader")
+        .expect("bootloader must have a .bootloader section");
+
+    Ok(Vec::from(bootloader_section.raw_data(&elf_file)).into_boxed_slice())
+}
+
+fn create_disk_image(config: &Config, mut kernel: File, kernel_info_block: KernelInfoBlock,
+    bootloader_data: &[u8]) -> Result<(), Error>
+{
+    use std::io::{Read, Write};
+
+    println!("Creating disk image at {}", config.output.display());
+    let mut output = File::create(&config.output)?;
+    output.write_all(&bootloader_data)?;
+    output.write_all(&kernel_info_block)?;
+
+    // write out kernel elf file
+    let kernel_size = kernel.metadata()?.len();
+    let mut buffer = [0u8; 1024];
+    loop {
+        let (n, interrupted) = match kernel.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(n) => (n, false),
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => (0, true),
+            Err(e) => Err(e)?,
+        };
+        if !interrupted {
+            output.write_all(&buffer[..n])?
+        }
+    }
+
+    let padding_size = ((512 - (kernel_size % 512)) % 512) as usize;
+    let padding = [0u8; 512];
+    output.write_all(&padding[..padding_size])?;
+
+    Ok(())
+}

--- a/src/build.rs
+++ b/src/build.rs
@@ -137,6 +137,11 @@ fn download_bootloader(out_dir: &Path, config: &Config) -> Result<CrateMetadata,
                     git = "{}"
             "#, git).as_bytes())?;
         }
+        if let &Some(ref branch) = &config.bootloader.branch {
+            cargo_toml_file.write_all(format!(r#"
+                    branch = "{}"
+            "#, branch).as_bytes())?;
+        }
         if let &Some(ref path) = &config.bootloader.path {
             cargo_toml_file.write_all(format!(r#"
                     path = "{}"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,126 @@
+use std::path::{Path, PathBuf};
+use Error;
+use toml::Value;
+
+pub struct Config {
+    pub manifest_path: PathBuf,
+    pub default_target: Option<String>,
+    pub bootloader: BootloaderConfig,
+}
+
+pub struct BootloaderConfig {
+    pub name: String,
+    pub precompiled: bool,
+    pub target: String,
+    pub version: Option<String>,
+    pub git: Option<String>,
+    pub path: Option<PathBuf>,
+}
+
+pub(crate) fn read_config(manifest_path: PathBuf) -> Result<Config, Error> {
+    use std::{fs::File, io::Read};
+    let cargo_toml: Value = {
+        let mut content = String::new();
+        File::open(&manifest_path)?.read_to_string(&mut content)?;
+        content.parse()?
+    };
+
+    let metadata = cargo_toml.get("package")
+        .and_then(|table| table.get("metadata"))
+        .and_then(|table| table.get("bootimage"));
+    let metadata = match metadata {
+        None => {
+            return Ok(ConfigBuilder {
+               manifest_path: Some(manifest_path),
+               ..Default::default()
+            }.into())
+        }
+        Some(metadata) => metadata.as_table().ok_or(Error::Config(
+            format!("Bootimage configuration invalid: {:?}", metadata)
+        ))?,
+    };
+
+    let mut config = ConfigBuilder {
+        manifest_path: Some(manifest_path),
+        ..Default::default()
+    };
+
+    for (key, value) in metadata {
+        match (key.as_str(), value.clone()) {
+            ("default-target", Value::String(s)) => config.default_target = From::from(s),
+            ("bootloader", Value::Table(t)) => {
+                let mut bootloader_config = BootloaderConfigBuilder::default();
+                for (key, value) in t {
+                    match (key.as_str(), value) {
+                        ("name", Value::String(s)) => bootloader_config.name = From::from(s),
+                        ("precompiled", Value::Boolean(b)) => {
+                            bootloader_config.precompiled = From::from(b)
+                        },
+                        ("version", Value::String(s)) => bootloader_config.version = From::from(s),
+                        ("git", Value::String(s)) => bootloader_config.git = From::from(s),
+                        ("path", Value::String(s)) => {
+                            bootloader_config.path = Some(Path::new(&s).canonicalize()?);
+                        }
+                        (key, value) => {
+                            Err(Error::Config(format!("unexpected \
+                                `package.metadata.bootimage.bootloader` key `{}` with value `{}`",
+                                key, value)))?
+                        }
+                    }
+                }
+                config.bootloader = Some(bootloader_config);
+            }
+            (key, value) => {
+                Err(Error::Config(format!("unexpected `package.metadata.bootimage` \
+                    key `{}` with value `{}`", key, value)))?
+            }
+        }
+    }
+    Ok(config.into())
+}
+
+#[derive(Default)]
+struct ConfigBuilder {
+    manifest_path: Option<PathBuf>,
+    default_target: Option<String>,
+    bootloader: Option<BootloaderConfigBuilder>,
+}
+
+#[derive(Default)]
+struct BootloaderConfigBuilder {
+    name: Option<String>,
+    precompiled: Option<bool>,
+    target: Option<String>,
+    version: Option<String>,
+    git: Option<String>,
+    path: Option<PathBuf>,
+}
+
+impl Into<Config> for ConfigBuilder {
+    fn into(self) -> Config {
+        let default_bootloader_config = BootloaderConfigBuilder {
+            precompiled: Some(true),
+            ..Default::default()
+        };
+        Config {
+            manifest_path: self.manifest_path.expect("manifest path must be set"),
+            default_target: self.default_target,
+            bootloader: self.bootloader.unwrap_or(default_bootloader_config).into(),
+        }
+    }
+}
+
+impl Into<BootloaderConfig> for BootloaderConfigBuilder {
+    fn into(self) -> BootloaderConfig {
+        let precompiled = self.precompiled.unwrap_or(false);
+        let default_name = if precompiled { "bootloader_precompiled" } else { "bootloader" };
+        BootloaderConfig {
+            name: self.name.unwrap_or(default_name.into()),
+            precompiled,
+            target: self.target.unwrap_or("x86_64-bootloader".into()),
+            version: self.version,
+            git: self.git,
+            path: self.path,
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub struct BootloaderConfig {
     pub target: String,
     pub version: Option<String>,
     pub git: Option<String>,
+    pub branch: Option<String>,
     pub path: Option<PathBuf>,
 }
 
@@ -60,6 +61,7 @@ pub(crate) fn read_config(manifest_path: PathBuf) -> Result<Config, Error> {
                         },
                         ("version", Value::String(s)) => bootloader_config.version = From::from(s),
                         ("git", Value::String(s)) => bootloader_config.git = From::from(s),
+                        ("branch", Value::String(s)) => bootloader_config.branch = From::from(s),
                         ("path", Value::String(s)) => {
                             bootloader_config.path = Some(Path::new(&s).canonicalize()?);
                         }
@@ -95,6 +97,7 @@ struct BootloaderConfigBuilder {
     precompiled: Option<bool>,
     target: Option<String>,
     version: Option<String>,
+    branch: Option<String>,
     git: Option<String>,
     path: Option<PathBuf>,
 }
@@ -124,6 +127,7 @@ impl Into<BootloaderConfig> for BootloaderConfigBuilder {
             target: self.target.unwrap_or("x86_64-bootloader".into()),
             version: self.version,
             git: self.git,
+            branch: self.branch,
             path: self.path,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use toml::Value;
 pub struct Config {
     pub manifest_path: PathBuf,
     pub default_target: Option<String>,
+    pub output: PathBuf,
     pub bootloader: BootloaderConfig,
 }
 
@@ -48,6 +49,7 @@ pub(crate) fn read_config(manifest_path: PathBuf) -> Result<Config, Error> {
     for (key, value) in metadata {
         match (key.as_str(), value.clone()) {
             ("default-target", Value::String(s)) => config.default_target = From::from(s),
+            ("output", Value::String(s)) => config.output = Some(PathBuf::from(s)),
             ("bootloader", Value::Table(t)) => {
                 let mut bootloader_config = BootloaderConfigBuilder::default();
                 for (key, value) in t {
@@ -83,6 +85,7 @@ pub(crate) fn read_config(manifest_path: PathBuf) -> Result<Config, Error> {
 struct ConfigBuilder {
     manifest_path: Option<PathBuf>,
     default_target: Option<String>,
+    output: Option<PathBuf>,
     bootloader: Option<BootloaderConfigBuilder>,
 }
 
@@ -105,6 +108,7 @@ impl Into<Config> for ConfigBuilder {
         Config {
             manifest_path: self.manifest_path.expect("manifest path must be set"),
             default_target: self.default_target,
+            output: self.output.unwrap_or(PathBuf::from("bootimage.bin")),
             bootloader: self.bootloader.unwrap_or(default_bootloader_config).into(),
         }
     }

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,0 +1,9 @@
+use Error;
+use std::process;
+
+const HELP: &str = include_str!("help.txt");
+
+pub(crate) fn help(explicitly_invoked: bool) -> Result<(), Error> {
+    print!("{}", HELP);
+    process::exit(if explicitly_invoked { 0 } else { 1 });
+}

--- a/src/help.txt
+++ b/src/help.txt
@@ -26,6 +26,7 @@ CONFIGURATION:
     name = "bootloader"             The bootloader crate name
     version = ""                    The bootloader version that should be used
     git = ""                        Use the bootloader from this git repository
+    branch = ""                     The git branch to use (defaults to master)
     path = ""                       Use the bootloader from this local path
     precompiled = false             Whether the bootloader crate is precompiled
     target = "x86_64-bootloader"    Target triple for compiling the bootloader

--- a/src/help.txt
+++ b/src/help.txt
@@ -1,0 +1,31 @@
+Creates a bootable disk image from a Rust kernel
+
+USAGE:
+    bootimage [OPTIONS]                 Display help and version information
+    bootimage build [BUILD_OPTIONS]     Create a bootable disk image (see below)
+
+OPTIONS:
+    -h, --help  Prints help information and exit
+    ---version  Prints version information and exit
+
+BUILD_OPTIONS:
+    Any options are directly passed to `cargo build` (see `cargo build --help`
+    for possible options). After building, a bootloader is downloaded and
+    built, and then combined with the kernel into a bootable disk image.
+
+CONFIGURATION:
+    The bootloader and the behavior of `bootimage build` can be configured
+    through a `[package.metadata.bootimage]` table in the `Cargo.toml`. The
+    following options are available:
+
+    [package.metadata.bootimage]
+    default-target = ""         This target is used if no `--target` is passed
+    output = "bootimage.bin"    The output file name
+
+    [package.metadata.bootimage.bootloader]
+    name = "bootloader"             The bootloader crate name
+    version = ""                    The bootloader version that should be used
+    git = ""                        Use the bootloader from this git repository
+    path = ""                       Use the bootloader from this local path
+    precompiled = false             Whether the bootloader crate is precompiled
+    target = "x86_64-bootloader"    Target triple for compiling the bootloader

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,21 +3,19 @@ extern crate xmas_elf;
 extern crate toml;
 extern crate cargo_metadata;
 
-use std::io;
-use std::fs::{self, File};
-use std::path::{Path, PathBuf};
-use std::process::{self, Command};
-use byteorder::{ByteOrder, LittleEndian};
+use std::{io, process};
 use args::Args;
-use config::Config;
-use cargo_metadata::Metadata as CargoMetadata;
-use cargo_metadata::Package as CrateMetadata;
 
 mod args;
 mod config;
+mod build;
+mod help;
 
-const BLOCK_SIZE: usize = 512;
-type KernelInfoBlock = [u8; BLOCK_SIZE];
+enum Command {
+    Build(Args),
+    Help(bool),
+    Version,
+}
 
 pub fn main() {
     use std::io::Write;
@@ -55,229 +53,11 @@ impl From<cargo_metadata::Error> for Error {
 }
 
 fn run() -> Result<(), Error> {
-    let mut args = args::parse_args();
-    let metadata = read_cargo_metadata(&args)?;
-    let crate_root = PathBuf::from(&metadata.workspace_root);
-    let manifest_path = args.manifest_path().as_ref().map(Clone::clone).unwrap_or({
-        let mut path = crate_root.clone();
-        path.push("Cargo.toml");
-        path
-    });
-    let config = config::read_config(manifest_path)?;
-
-    if args.target().is_none() {
-        if let Some(ref target) = config.default_target {
-            args.set_target(target.clone());
-        }
+    let command = args::parse_args();
+    match command {
+        Command::Build(args) => build::build(args),
+        Command::Help(explicitly_invoked) => help::help(explicitly_invoked),
+        Command::Version => Ok(println!("bootimage {}", env!("CARGO_PKG_VERSION"))),
     }
 
-    let (kernel, out_dir) = build_kernel(&args, &config, &metadata)?;
-
-    let kernel_size = kernel.metadata()?.len();
-    let kernel_info_block = create_kernel_info_block(kernel_size);
-
-    let bootloader = build_bootloader(&out_dir, &config)?;
-
-    create_disk_image(&config, kernel, kernel_info_block, &bootloader)?;
-
-    Ok(())
-}
-
-fn read_cargo_metadata(args: &Args) -> Result<CargoMetadata, cargo_metadata::Error> {
-    cargo_metadata::metadata(args.manifest_path().as_ref().map(PathBuf::as_path))
-}
-
-fn build_kernel(args: &args::Args, config: &Config, metadata: &CargoMetadata) -> Result<(File, PathBuf), Error> {
-    let crate_ = metadata.packages.iter()
-        .find(|p| Path::new(&p.manifest_path) == config.manifest_path)
-        .expect("Could not read crate name from cargo metadata");
-    let crate_name = &crate_.name;
-
-    let target_dir = PathBuf::from(&metadata.target_directory);
-
-    // compile kernel
-    println!("Building kernel");
-    let exit_status = run_xargo_build(&std::env::current_dir()?, &args.all_cargo)?;
-    if !exit_status.success() { std::process::exit(1) }
-
-    let mut out_dir = target_dir;
-    if let &Some(ref target) = args.target() {
-        out_dir.push(target);
-    }
-    if args.release() {
-        out_dir.push("release");
-    } else {
-        out_dir.push("debug");
-    }
-
-    let mut kernel_path = out_dir.clone();
-    kernel_path.push(crate_name);
-    let kernel = File::open(kernel_path)?;
-    Ok((kernel, out_dir))
-}
-
-fn run_xargo_build(pwd: &Path, args: &[String]) -> io::Result<std::process::ExitStatus> {
-    let mut command = Command::new("xargo");
-    command.arg("build");
-    command.current_dir(pwd).env("RUST_TARGET_PATH", pwd);
-    command.args(args);
-    command.status()
-}
-
-fn create_kernel_info_block(kernel_size: u64) -> KernelInfoBlock {
-    let kernel_size = if kernel_size <= u64::from(u32::max_value()) {
-        kernel_size as u32
-    } else {
-        panic!("Kernel can't be loaded by BIOS bootloader because is too big")
-    };
-
-    let mut kernel_info_block = [0u8; BLOCK_SIZE];
-    LittleEndian::write_u32(&mut kernel_info_block[0..4], kernel_size);
-
-    kernel_info_block
-}
-
-fn download_bootloader(out_dir: &Path, config: &Config) -> Result<CrateMetadata, Error> {
-    use std::io::Write;
-
-    let bootloader_dir = {
-        let mut dir = PathBuf::from(out_dir);
-        dir.push("bootloader");
-        dir
-    };
-
-    let cargo_toml = {
-        let mut dir = bootloader_dir.clone();
-        dir.push("Cargo.toml");
-        dir
-    };
-    let src_lib = {
-        let mut dir = bootloader_dir.clone();
-        dir.push("src");
-        fs::create_dir_all(dir.as_path())?;
-        dir.push("lib.rs");
-        dir
-    };
-
-    {
-        let mut cargo_toml_file = File::create(&cargo_toml)?;
-        cargo_toml_file.write_all(r#"
-            [package]
-            authors = ["author@example.com>"]
-            name = "bootloader_download_helper"
-            version = "0.0.0"
-
-        "#.as_bytes())?;
-        cargo_toml_file.write_all(format!(r#"
-            [dependencies.{}]
-        "#, config.bootloader.name).as_bytes())?;
-        if let &Some(ref version) = &config.bootloader.version {
-            cargo_toml_file.write_all(format!(r#"
-                    version = "{}"
-            "#, version).as_bytes())?;
-        }
-        if let &Some(ref git) = &config.bootloader.git {
-            cargo_toml_file.write_all(format!(r#"
-                    git = "{}"
-            "#, git).as_bytes())?;
-        }
-        if let &Some(ref path) = &config.bootloader.path {
-            cargo_toml_file.write_all(format!(r#"
-                    path = "{}"
-            "#, path.display()).as_bytes())?;
-        }
-
-        File::create(src_lib)?.write_all(r#"
-            #![no_std]
-        "#.as_bytes())?;
-    }
-
-    let mut command = Command::new("cargo");
-    command.arg("fetch");
-    command.current_dir(bootloader_dir);
-    assert!(command.status()?.success(), "Bootloader download failed.");
-
-    let metadata = cargo_metadata::metadata_deps(Some(&cargo_toml), true)?;
-    let bootloader = metadata.packages.iter().find(|p| p.name == config.bootloader.name)
-            .expect(&format!("Could not find crate named “{}”", config.bootloader.name));
-
-    Ok(bootloader.clone())
-}
-
-fn build_bootloader(out_dir: &Path, config: &Config) -> Result<Box<[u8]>, Error> {
-    use std::io::Read;
-
-    let bootloader_metadata = download_bootloader(out_dir, config)?;
-    let bootloader_dir = Path::new(&bootloader_metadata.manifest_path).parent().unwrap();
-
-
-    let bootloader_elf_path = if !config.bootloader.precompiled {
-        let args = &[
-            String::from("--target"),
-            config.bootloader.target.clone(),
-            String::from("--release"),
-        ];
-
-        println!("Building bootloader");
-        let exit_status = run_xargo_build(bootloader_dir, args)?;
-        if !exit_status.success() { std::process::exit(1) }
-
-        let mut bootloader_elf_path = bootloader_dir.to_path_buf();
-        bootloader_elf_path.push("target");
-        bootloader_elf_path.push(&config.bootloader.target);
-        bootloader_elf_path.push("release");
-        bootloader_elf_path.push("bootloader");
-        bootloader_elf_path
-    } else {
-        let mut bootloader_elf_path = bootloader_dir.to_path_buf();
-        bootloader_elf_path.push("bootloader");
-        bootloader_elf_path
-    };
-
-    let mut bootloader_elf_bytes = Vec::new();
-    let mut bootloader = File::open(&bootloader_elf_path).map_err(|err| {
-        Error::Bootloader(format!("Could not open bootloader at {}",
-            bootloader_elf_path.display()), err)
-    })?;
-    bootloader.read_to_end(&mut bootloader_elf_bytes)?;
-
-    // copy bootloader section of ELF file to bootloader_path
-    let elf_file = xmas_elf::ElfFile::new(&bootloader_elf_bytes).unwrap();
-    xmas_elf::header::sanity_check(&elf_file).unwrap();
-    let bootloader_section = elf_file.find_section_by_name(".bootloader")
-        .expect("bootloader must have a .bootloader section");
-
-    Ok(Vec::from(bootloader_section.raw_data(&elf_file)).into_boxed_slice())
-}
-
-fn create_disk_image(config: &Config, mut kernel: File, kernel_info_block: KernelInfoBlock,
-    bootloader_data: &[u8]) -> Result<(), Error>
-{
-    use std::io::{Read, Write};
-
-    println!("Creating disk image at {}", config.output.display());
-    let mut output = File::create(&config.output)?;
-    output.write_all(&bootloader_data)?;
-    output.write_all(&kernel_info_block)?;
-
-    // write out kernel elf file
-    let kernel_size = kernel.metadata()?.len();
-    let mut buffer = [0u8; 1024];
-    loop {
-        let (n, interrupted) = match kernel.read(&mut buffer) {
-            Ok(0) => break,
-            Ok(n) => (n, false),
-            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => (0, true),
-            Err(e) => Err(e)?,
-        };
-        if !interrupted {
-            output.write_all(&buffer[..n])?
-        }
-    }
-
-    let padding_size = ((512 - (kernel_size % 512)) % 512) as usize;
-    let padding = [0u8; 512];
-    output.write_all(&padding[..padding_size])?;
-
-    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn run() -> Result<(), Error> {
 
     let bootloader = build_bootloader(&out_dir, &config)?;
 
-    create_disk_image(&args, kernel, kernel_info_block, &bootloader)?;
+    create_disk_image(&config, kernel, kernel_info_block, &bootloader)?;
 
     Ok(())
 }
@@ -250,13 +250,13 @@ fn build_bootloader(out_dir: &Path, config: &Config) -> Result<Box<[u8]>, Error>
     Ok(Vec::from(bootloader_section.raw_data(&elf_file)).into_boxed_slice())
 }
 
-fn create_disk_image(args: &Args, mut kernel: File, kernel_info_block: KernelInfoBlock,
+fn create_disk_image(config: &Config, mut kernel: File, kernel_info_block: KernelInfoBlock,
     bootloader_data: &[u8]) -> Result<(), Error>
 {
     use std::io::{Read, Write};
 
-    println!("Creating disk image at {}", args.output.display());
-    let mut output = File::create(&args.output)?;
+    println!("Creating disk image at {}", config.output.display());
+    let mut output = File::create(&config.output)?;
     output.write_all(&bootloader_data)?;
     output.write_all(&kernel_info_block)?;
 


### PR DESCRIPTION
Rewrite using `cargo metadata`. This allows us to use `cargo` for downloading the bootloader and thus removes the dependency on `curl`. It also allows us to specify the bootloader dependency using the complete power of `cargo`: crates.io versions, git repositories, or local paths.

The new version uses subcommands (e.g. `bootimage build`), because we might want to add more subcommands in the future (e.g. `bootimage run` for invoking QEMU). So instead of `bootimage --target […]` the command needs to be invoked as `bootimage build --target […]`. We now pass all addional arguments directly to `xargo/cargo`, which e.g. allows passing the `--freeze` option. Fixes #5.

Another big change is that we allow configuration through the `Cargo.toml` (see the Readme). We also have a `--help` message and support for `--version`.

Fixes #4 
Fixes #3 

cc @lachlansneff @steveklabnik