### PR TITLE
Add minimum-image-size option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,7 @@ Configuration is done through a through a `[package.metadata.bootimage]` table i
     [package.metadata.bootimage]
     default-target = ""         # This target is used if no `--target` is passed
     output = "bootimage.bin"    # The output file name
+    minimum-image-size = 0      # The minimum output file size (in MiB)
 
     [package.metadata.bootimage.bootloader]
     name = "bootloader"             # The bootloader crate name

--- a/src/build.rs
+++ b/src/build.rs
@@ -240,5 +240,13 @@ fn create_disk_image(config: &Config, mut kernel: File, kernel_info_block: Kerne
     let padding = [0u8; 512];
     output.write_all(&padding[..padding_size])?;
 
+    if let Some(min_size) = config.minimum_image_size {
+        // we already wrote to output successfully,
+        // both metadata and set_len should succeed.
+        if output.metadata()?.len() < min_size {
+            output.set_len(min_size)?;
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
This change adds an optional "minimum-image-size" field to be read from the Cargo.toml.
The size of the output file is padded to minimum-image-size (in MiB).

This option is helpful because VirtualBox can only create .vdi images with a minimum size of 4 MiB.
Use following command to convert the bin file to a vdi file: 
`VBoxManage convertfromraw bootimage.bin bootimage.vdi --format vdi --variant Standard --uuid=<some-uuid-you-generated>`