### PR TITLE
Always use a version for bootloader download; default to 0.2.0-alpha

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -233,20 +233,11 @@ fn download_bootloader(bootloader_dir: &Path, config: &Config) -> Result<CrateMe
             format!(
                 r#"
             [dependencies.{}]
+            version = "{}"
         "#,
-                config.bootloader.name
+                config.bootloader.name, config.bootloader.version
             ).as_bytes(),
         ).context("Failed to write to Cargo.toml for bootloader download crate")?;
-        if let &Some(ref version) = &config.bootloader.version {
-            cargo_toml_file.write_all(
-                format!(
-                    r#"
-                    version = "{}"
-            "#,
-                    version
-                ).as_bytes(),
-            ).context("Failed to write to Cargo.toml for bootloader download crate")?;
-        }
         if let &Some(ref git) = &config.bootloader.git {
             cargo_toml_file.write_all(
                 format!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ pub struct BootloaderConfig {
     pub name: String,
     pub precompiled: bool,
     pub target: PathBuf,
-    pub version: Option<String>,
+    pub version: String,
     pub git: Option<String>,
     pub branch: Option<String>,
     pub path: Option<PathBuf>,
@@ -172,7 +172,7 @@ impl Into<BootloaderConfig> for BootloaderConfigBuilder {
             precompiled,
             target: self.target
                 .unwrap_or(PathBuf::from("x86_64-bootloader.json")),
-            version: self.version,
+            version: self.version.unwrap_or("0.2.0-alpha".into()),
             git: self.git,
             branch: self.branch,
             path: self.path,


### PR DESCRIPTION
I'm planning some breaking changes on bootimage and the bootloader. To avoid breaking users that don't specify a version (and thus always use the latest bootloader), this PR defaults to version `0.2.0-alpha` (the latest version currently).