### PR TITLE
Use rayon when running `bootimage test`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,12 @@
 [[package]]
+name = "arrayvec"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +34,7 @@ dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -59,8 +68,44 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "either"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -82,9 +127,32 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy_static"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memoffset"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nodrop"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num_cpus"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -103,8 +171,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -210,20 +304,32 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
 "checksum byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9"
 "checksum cargo_metadata 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1efca0b863ca03ed4c109fb1c55e0bc4bbeb221d3e103d86251046b06a526bd0"
 "checksum cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "2119ea4867bd2b8ed3aecab467709720b2d55b1bcfe09f772fd68066eaf15275"
 "checksum cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efe5c877e17a9c717a0bf3613b2709f723202c4e4675cc8f12926ded29bcb17e"
+"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
+"checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
+"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
+"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum proc-macro2 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c65b1ea15bb859d922cade2d1765b4b88beac339cbfad545ef2d2ef8c8215ee6"
 "checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
+"checksum rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473"
+"checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)" = "0c3adf19c07af6d186d91dae8927b83b0553d07ca56cbf7f2f32560455c91920"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ repository = "https://github.com/rust-osdev/bootimage"
 
 [dependencies]
 byteorder = "1.2.1"
+rayon = "1.0"
 toml = "0.4.5"
-xmas-elf = "0.6.1"
 wait-timeout = "0.1"
+xmas-elf = "0.6.1"
 
 [dependencies.cargo_metadata]
 version = "0.5.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 extern crate byteorder;
 extern crate cargo_metadata;
+extern crate rayon;
 extern crate toml;
 extern crate wait_timeout;
 extern crate xmas_elf;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,7 @@
 use args::Args;
 use build;
 use failure::{Error, ResultExt};
+use rayon::prelude::*;
 use std::io::Write;
 use std::path::Path;
 use std::time::Duration;
@@ -29,88 +30,88 @@ pub(crate) fn test(args: Args) -> Result<(), Error> {
         test_config
     };
 
-    let mut tests = Vec::new();
-
-    let crate_metadata = metadata
+    let tests = metadata
         .packages
         .iter()
         .find(|p| Path::new(&p.manifest_path) == config.manifest_path)
-        .expect("Could not read crate name from cargo metadata");
-    let target_iter = crate_metadata.targets.iter();
-    for target in target_iter.filter(|t| t.kind == ["bin"] && t.name.starts_with("test-")) {
-        println!("{}", target.name);
+        .expect("Could not read crate name from cargo metadata")
+        .targets
+        .par_iter()
+        .filter(|t| t.kind == ["bin"] && t.name.starts_with("test-"))
+        .map(|target| {
+            println!("RUN: {}", target.name);
 
-        let mut target_args = test_args.clone();
-        target_args.set_bin_name(target.name.clone());
-        let test_path = build::build_impl(
-            &target_args,
-            &test_config,
-            &metadata,
-            &root_dir,
-            &out_dir,
-            false,
-        )?;
+            let mut target_args = test_args.clone();
+            target_args.set_bin_name(target.name.clone());
+            let test_path = build::build_impl(
+                &target_args,
+                &test_config,
+                &metadata,
+                &root_dir,
+                &out_dir,
+                false,
+            )?;
 
-        let test_result;
-        let output_file = format!("{}-output.txt", test_path.display());
+            let test_result;
+            let output_file = format!("{}-output.txt", test_path.display());
 
-        let mut command = process::Command::new("qemu-system-x86_64");
-        command.arg("-drive");
-        command.arg(format!("format=raw,file={}", test_path.display()));
-        command.arg("-device");
-        command.arg("isa-debug-exit,iobase=0xf4,iosize=0x04");
-        command.arg("-display");
-        command.arg("none");
-        command.arg("-serial");
-        command.arg(format!("file:{}", output_file));
-        command.stderr(process::Stdio::null());
-        let mut child = command
-            .spawn()
-            .with_context(|e| format_err!("Failed to launch QEMU: {:?}\n{}", command, e))?;
-        let timeout = Duration::from_secs(60);
-        match child
-            .wait_timeout(timeout)
-            .with_context(|e| format!("Failed to wait with timeout: {}", e))?
-        {
-            None => {
-                child
-                    .kill()
-                    .with_context(|e| format!("Failed to kill QEMU: {}", e))?;
-                child
-                    .wait()
-                    .with_context(|e| format!("Failed to wait for QEMU process: {}", e))?;
-                test_result = TestResult::TimedOut;
-                writeln!(io::stderr(), "Timed Out")?;
-            }
-            Some(_) => {
-                let output = fs::read_to_string(&output_file).with_context(|e| {
-                    format_err!("Failed to read test output file {}: {}", output_file, e)
-                })?;
-                if output.starts_with("ok\n") {
-                    test_result = TestResult::Ok;
-                    println!("Ok");
-                } else if output.starts_with("failed\n") {
-                    test_result = TestResult::Failed;
-                    writeln!(io::stderr(), "Failed:")?;
-                    for line in output[7..].lines() {
-                        writeln!(io::stderr(), "    {}", line)?;
-                    }
-                } else {
-                    test_result = TestResult::Invalid;
-                    writeln!(io::stderr(), "Failed: Invalid Output:")?;
-                    for line in output.lines() {
-                        writeln!(io::stderr(), "    {}", line)?;
+            let mut command = process::Command::new("qemu-system-x86_64");
+            command.arg("-drive");
+            command.arg(format!("format=raw,file={}", test_path.display()));
+            command.arg("-device");
+            command.arg("isa-debug-exit,iobase=0xf4,iosize=0x04");
+            command.arg("-display");
+            command.arg("none");
+            command.arg("-serial");
+            command.arg(format!("file:{}", output_file));
+            command.stderr(process::Stdio::null());
+            let mut child = command
+                .spawn()
+                .with_context(|e| format_err!("Failed to launch QEMU: {:?}\n{}", command, e))?;
+            let timeout = Duration::from_secs(60);
+            match child
+                .wait_timeout(timeout)
+                .with_context(|e| format!("Failed to wait with timeout: {}", e))?
+            {
+                None => {
+                    child
+                        .kill()
+                        .with_context(|e| format!("Failed to kill QEMU: {}", e))?;
+                    child
+                        .wait()
+                        .with_context(|e| format!("Failed to wait for QEMU process: {}", e))?;
+                    test_result = TestResult::TimedOut;
+                    writeln!(io::stderr(), "Timed Out")?;
+                }
+                Some(_) => {
+                    let output = fs::read_to_string(&output_file).with_context(|e| {
+                        format_err!("Failed to read test output file {}: {}", output_file, e)
+                    })?;
+                    if output.starts_with("ok\n") {
+                        test_result = TestResult::Ok;
+                        println!("OK: {}", target.name);
+                    } else if output.starts_with("failed\n") {
+                        test_result = TestResult::Failed;
+                        writeln!(io::stderr(), "Failed:")?;
+                        for line in output[7..].lines() {
+                            writeln!(io::stderr(), "    {}", line)?;
+                        }
+                    } else {
+                        test_result = TestResult::Invalid;
+                        writeln!(io::stderr(), "Failed: Invalid Output:")?;
+                        for line in output.lines() {
+                            writeln!(io::stderr(), "    {}", line)?;
+                        }
                     }
                 }
             }
-        }
-        println!("");
 
-        tests.push((target.name.clone(), test_result))
-    }
+            Ok((target.name.clone(), test_result))
+        })
+        .collect::<Result<Vec<(String, TestResult)>, Error>>()?;
 
     if tests.iter().all(|t| t.1 == TestResult::Ok) {
-        println!("All tests succeeded.");
+        println!("\nAll tests succeeded.");
         Ok(())
     } else {
         writeln!(io::stderr(), "The following tests failed:")?;


### PR DESCRIPTION
Fixes #21 

This PR adds `rayon` and uses it during the `bootimage test` command so that all the tests are run in parallel.

There's a few caveats though:

* While the tests are building they block each other while waiting to build
* Their output sometimes mangles each other since the calls are done in parallel

Aside from those, the _actual tests themselves_ are run in parallel, just not when they build..

Suggestions welcome for improvements!