### PR TITLE
remove run command duplication

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -12,21 +12,10 @@ pub(crate) fn test(args: Args) -> Result<(), Error> {
     let (args, config, metadata, root_dir, out_dir) = build::common_setup(args)?;
 
     let test_args = args.clone();
-    let test_run_command = vec![
-        "qemu-system-x86_64".into(),
-        "-drive".into(),
-        "format=raw,file={}".into(),
-        "-device".into(),
-        "isa-debug-exit,iobase=0xf4,iosize=0x04".into(),
-        "-display".into(),
-        "none".into(),
-        "-serial".into(),
-        "file:{}-output.txt".into(),
-    ];
+
     let test_config = {
         let mut test_config = config.clone();
         test_config.output = None;
-        test_config.run_command = test_run_command;
         test_config
     };
 


### PR DESCRIPTION
The run commands are specified twice in the entry point for the test subcommand. I wanted to remove the duplication, and it looks like the first time the commands are specified they are passed into a config object which is passed around a bit but ultimately doesn't use them. 

For now I've simply removed them, allowing the value to fall back to whatever comes from `common_setup`. However, given that parameter is unnecessary in the `test` case, it suggests a nicer solution might be to create a specific test config struct which doesn't contain the `run_command` parameter. I'd be happy to take on implementing that if there is interest. 

Thanks for your work on this library and the other rust-osdev tooling. I've been working through the [os tutorials](https://os.phil-opp.com) and it has been very enlightening. 