### PR TITLE
Canonicalize paths before comparing them in `bootimage test`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
+- Canonicalize paths before comparing them when invoking `bootimage test`
+  - This caused an error on Windows where the path in the cargo metadata is not fully canonicalized
+
 # 0.6.3
 
-- Canonicalize paths before comparing them
+- Canonicalize paths before comparing them when invoking `bootimage build`
   - This caused an error on Windows where the path in the cargo metadata is not fully canonicalized
 
 # 0.6.2

--- a/src/test.rs
+++ b/src/test.rs
@@ -22,7 +22,12 @@ pub(crate) fn test(args: Args) -> Result<(), Error> {
     let test_targets = metadata
         .packages
         .iter()
-        .find(|p| Path::new(&p.manifest_path) == config.manifest_path)
+        .find(|p| {
+            Path::new(&p.manifest_path)
+                .canonicalize()
+                .map(|path| path == config.manifest_path)
+                .unwrap_or(false)
+        })
         .expect("Could not read crate name from cargo metadata")
         .targets
         .iter()


### PR DESCRIPTION
This fixes `bootimage test` on some Windows versions where cargo-metadata does not report fully canonicalized paths.