### PR TITLE
New features for `bootimage runner`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+
+- Make `bootimage runner` pass additional arguments to the run command (e.g. QEMU).
+
 # 0.7.1
 
 - Fix for backwards compatibility: Ignore `test-` executables for `bootimage run`.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,13 @@
 
-- Make `bootimage runner` pass additional arguments to the run command (e.g. QEMU).
-- Apply `test-timeout` config key when running tests in `bootimage runner`
-    - All binaries in the `target/deps` folder are considered tests for this feature
+- New features for `bootimage runner`
+    - Pass additional arguments to the run command (e.g. QEMU)
+    - Consider all binaries in the `target/deps` folder as test executables
+    - Apply `test-timeout` config key when running tests in `bootimage runner`
+    - Don't apply `run-args` for test executables
+    - Add a new `test-args` config key for test arguments
+    - Add a new `test-success-exit-code` config key for interpreting an exit code as success
+        - This is useful when the `isa-debug-exit` QEMU device is used.
+    - Improve printing of the run command (print string instead of array, print non-canonicalized executable path, respect `--quiet`)
 
 # 0.7.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 
 - Make `bootimage runner` pass additional arguments to the run command (e.g. QEMU).
+- Apply `test-timeout` config key when running tests in `bootimage runner`
+    - All binaries in the `target/deps` folder are considered tests for this feature
 
 # 0.7.1
 

--- a/Readme.md
+++ b/Readme.md
@@ -72,9 +72,16 @@ Configuration is done through a through a `[package.metadata.bootimage]` table i
     # Applies to `bootimage run` and `bootimage runner`
     run-command = ["qemu-system-x86_64", "-drive", "format=raw,file={}"]
 
-    # Additional arguments passed to the runner on `bootimage run` or `bootimage runner`
-    # (this is useful when you want to add some arguments to the default QEMU command)
+    # Additional arguments passed to the run command for non-test executables
+    # Applies to `bootimage run` and `bootimage runner`
     run-args = []
+
+    # Additional arguments passed to the run command for test executables
+    # Applies to `bootimage runner`
+    test-args = []
+
+    # An exit code that should be considered as success for test executables
+    test-success-exit-code = {integer}
 
     # The timeout for running a test through `bootimage test` or `bootimage runner` (in seconds)
     test-timeout = 300

--- a/Readme.md
+++ b/Readme.md
@@ -67,8 +67,9 @@ Configuration is done through a through a `[package.metadata.bootimage]` table i
     # This target is used if no `--target` is passed
     default-target = ""
 
-    # The command invoked on `bootimage run` or `bootimage runner`
-    # (the "{}" will be replaced with the path to the bootable disk image)
+    # The command invoked with the created bootimage (the "{}" will be replaced
+    # with the path to the bootable disk image)
+    # Applies to `bootimage run` and `bootimage runner`
     run-command = ["qemu-system-x86_64", "-drive", "format=raw,file={}"]
 
     # Additional arguments passed to the runner on `bootimage run` or `bootimage runner`

--- a/Readme.md
+++ b/Readme.md
@@ -75,7 +75,7 @@ Configuration is done through a through a `[package.metadata.bootimage]` table i
     # (this is useful when you want to add some arguments to the default QEMU command)
     run-args = []
 
-    # The timeout for running an integration test through `bootimage test` in seconds
+    # The timeout for running a test through `bootimage test` or `bootimage runner` (in seconds)
     test-timeout = 300
 ```
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,3 +198,48 @@ jobs:
       if [ $? -eq 109 ]; then (exit 0); else (exit 1); fi
     workingDirectory: example-kernels/runner
     displayName: 'Run `cargo xrun` for "runner" kernel'
+
+- job: formatting
+  displayName: Check Formatting
+
+  strategy:
+    matrix:
+      linux:
+        image_name: 'ubuntu-16.04'
+        rustup_toolchain: stable
+
+  pool:
+    vmImage: $(image_name)
+
+  steps:
+  - bash: |
+      echo "Hello world from $AGENT_NAME running on $AGENT_OS"
+      echo "Reason: $BUILD_REASON"
+      case "$BUILD_REASON" in
+              "Manual") echo "$BUILD_REQUESTEDFOR manually queued the build." ;;
+              "PullRequest") echo "This is a CI build for a pull request on $BUILD_REQUESTEDFOR." ;;
+              "IndividualCI") echo "This is a CI build for $BUILD_REQUESTEDFOR." ;;
+              "BatchedCI") echo "This is a batched CI build for $BUILD_REQUESTEDFOR." ;;
+          *) "$BUILD_REASON" ;;
+      esac
+    displayName: 'Build Info'
+    continueOnError: true
+
+  - script: |
+      set -euxo pipefail
+      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOOLCHAIN
+      echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+    condition: or(eq( variables['Agent.OS'], 'Linux' ),  eq( variables['Agent.OS'], 'Darwin' ))
+    displayName: 'Install Rust'
+
+  - script: |
+      rustc -Vv
+      cargo -V
+    displayName: 'Print Rust Version'
+    continueOnError: true
+
+  - script: rustup component add rustfmt
+    displayName: 'Install Rustfmt'
+
+  - script: cargo fmt -- --check
+    displayName: 'Check Formatting'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -199,6 +199,10 @@ jobs:
     workingDirectory: example-kernels/runner
     displayName: 'Run `cargo xrun` for "runner" kernel'
 
+  - script: cargo xtest
+    workingDirectory: example-kernels/runner-test
+    displayName: 'Run `cargo xtest` for "runner-test" kernel'
+
 - job: formatting
   displayName: Check Formatting
 

--- a/example-kernels/Cargo.lock
+++ b/example-kernels/Cargo.lock
@@ -12,8 +12,8 @@ dependencies = [
 name = "basic"
 version = "0.1.0"
 dependencies = [
- "bootloader 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -28,7 +28,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bootloader"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -41,23 +41,23 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.32"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "default-target-bootimage"
 version = "0.1.0"
 dependencies = [
- "bootloader 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "default-target-cargo"
 version = "0.1.0"
 dependencies = [
- "bootloader 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -170,23 +170,23 @@ name = "remove_dir_all"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "runner"
 version = "0.1.0"
 dependencies = [
- "bootloader 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "runner-test"
 version = "0.1.0"
 dependencies = [
- "bootloader 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -242,19 +242,19 @@ dependencies = [
 name = "testing-qemu-exit-code"
 version = "0.1.0"
 dependencies = [
- "bootloader 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "testing-serial-result"
 version = "0.1.0"
 dependencies = [
- "bootloader 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "uart_16550 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "array-init 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -355,8 +355,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum array-init 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
 "checksum bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
-"checksum bootloader 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a70143804c70c39473b3d7e99b870fb4f7f319f3100386f5dedf06e11e1799f0"
-"checksum cc 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "ad0daef304fa0b4238f5f7ed7178774b43b06f6a9b6509f6642bef4ff1f7b9b2"
+"checksum bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a8f7c11b70b5781deec899276f7d67611eaf296a8bd7dcc9b9d37c71a5389c52"
+"checksum cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83"
 "checksum fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7c6c16d316ccdac21a4dd648e314e76facbbaf316e83ca137d0857a9c07419d0"
 "checksum font8x8 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b81d84c3c978af7d05d31a2198af4b9ba956d819d15d8f6d58fc150e33f8dc1f"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
@@ -384,11 +384,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f70329e2cbe45d6c97a5112daad40c34cd9a4e18edb5a2a18fefeb584d8d25e5"
 "checksum ux 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "88dfeb711b61ce620c0cb6fd9f8e3e678622f0c971da2a63c4b3e25e88ed012f"
-"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum x86_64 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd647af1614659e1febec1d681231aea4ebda4818bf55a578aff02f3e4db4b4"
 "checksum x86_64 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f9258d7e2dd25008d69e8c9e9ee37865887a5e1e3d06a62f1cb3f6c209e6f177"
-"checksum x86_64 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8f7e92e985f4052118fd69f2b366c67e91288c0f01f4ae52610dce236425dfa0"
+"checksum x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0a8201f52d2c7b373c7243dcdfb27c0dd5012f221ef6a126f507ee82005204"
 "checksum xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22678df5df766e8d1e5d609da69f0c3132d794edf6ab5e75e7abcd2270d4cf58"
 "checksum zero 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f1bc8a6b2005884962297587045002d8cfb8dcec9db332f4ca216ddc5de82c5"

--- a/example-kernels/Cargo.lock
+++ b/example-kernels/Cargo.lock
@@ -182,6 +182,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "runner-test"
+version = "0.1.0"
+dependencies = [
+ "bootloader 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/example-kernels/Cargo.toml
+++ b/example-kernels/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "default-target-bootimage",
     "default-target-cargo",
     "runner",
+    "runner-test",
     "testing-qemu-exit-code",
     "testing-serial-result",
 ]

--- a/example-kernels/runner-test/.cargo/config
+++ b/example-kernels/runner-test/.cargo/config
@@ -1,0 +1,5 @@
+[build]
+target = "../x86_64-bootimage-example-kernels.json"
+
+[target.'cfg(target_os = "none")']
+runner = "bootimage runner"

--- a/example-kernels/runner-test/.gitignore
+++ b/example-kernels/runner-test/.gitignore
@@ -1,0 +1,2 @@
+/target/
+**/*.rs.bk

--- a/example-kernels/runner-test/Cargo.toml
+++ b/example-kernels/runner-test/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "runner-test"
+version = "0.1.0"
+authors = ["Philipp Oppermann <dev@phil-opp.com>"]
+edition = "2018"
+
+[[test]]
+name = "no-harness"
+harness = false
+
+[dependencies]
+bootloader = "0.5.1"
+x86_64 = "0.5.3"
+
+[package.metadata.bootimage]
+test-success-exit-code = 33 # (0x10 << 1) | 1
+test-args = ["-device", "isa-debug-exit,iobase=0xf4,iosize=0x04", "-display", "none"]

--- a/example-kernels/runner-test/src/lib.rs
+++ b/example-kernels/runner-test/src/lib.rs
@@ -1,0 +1,63 @@
+#![no_std]
+#![cfg_attr(test, no_main)]
+
+#![feature(custom_test_frameworks)]
+#![test_runner(crate::test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+pub fn test_runner(tests: &[&dyn Fn()]) {
+    for test in tests.iter() {
+        test();
+    }
+
+    unsafe { exit_qemu(ExitCode::Success); }
+}
+
+#[test_case]
+fn test1() {
+    assert_eq!(0, 0);
+}
+
+#[test_case]
+fn test2() {
+    assert_eq!(1, 1);
+}
+
+pub enum ExitCode {
+    Success,
+    Failed
+}
+
+impl ExitCode {
+    fn code(&self) -> u32 {
+        match self {
+            ExitCode::Success => 0x10,
+            ExitCode::Failed => 0x11,
+        }
+    }
+}
+
+/// exit QEMU (see https://os.phil-opp.com/integration-tests/#shutting-down-qemu)
+pub unsafe fn exit_qemu(exit_code: ExitCode) {
+    use x86_64::instructions::port::Port;
+
+    let mut port = Port::<u32>::new(0xf4);
+    port.write(exit_code.code());
+}
+
+#[cfg(test)]
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    test_main();
+
+    unsafe { exit_qemu(ExitCode::Failed); }
+
+    loop {}
+}
+
+#[cfg(test)]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe { exit_qemu(ExitCode::Failed); }
+    loop {}
+}

--- a/example-kernels/runner-test/src/main.rs
+++ b/example-kernels/runner-test/src/main.rs
@@ -1,0 +1,30 @@
+#![no_std]
+#![no_main]
+
+#![feature(custom_test_frameworks)]
+#![test_runner(runner_test::test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+use core::panic::PanicInfo;
+use runner_test::{exit_qemu, ExitCode};
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    #[cfg(test)]
+    test_main();
+
+    unsafe { exit_qemu(ExitCode::Failed); }
+
+    loop {}
+}
+
+#[test_case]
+fn test1() {
+    assert_eq!(0, 0);
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    unsafe { exit_qemu(ExitCode::Failed); }
+    loop {}
+}

--- a/example-kernels/runner-test/tests/no-harness.rs
+++ b/example-kernels/runner-test/tests/no-harness.rs
@@ -1,0 +1,21 @@
+#![no_std]
+#![no_main]
+
+use runner_test::{exit_qemu, ExitCode};
+use core::panic::PanicInfo;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    unsafe {
+        exit_qemu(ExitCode::Success);
+    }
+    loop {}
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    unsafe {
+        exit_qemu(ExitCode::Failed);
+    }
+    loop {}
+}

--- a/example-kernels/runner-test/tests/should-panic.rs
+++ b/example-kernels/runner-test/tests/should-panic.rs
@@ -1,0 +1,35 @@
+#![no_std] // don't link the Rust standard library
+#![no_main] // disable all Rust-level entry points
+
+#![feature(custom_test_frameworks)]
+#![test_runner(crate::test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+use core::panic::PanicInfo;
+use runner_test::{exit_qemu, ExitCode};
+
+#[no_mangle] // don't mangle the name of this function
+pub extern "C" fn _start() -> ! {
+    test_main();
+
+    unsafe { exit_qemu(ExitCode::Failed); }
+
+    loop {}
+}
+
+pub fn test_runner(tests: &[&dyn Fn()]) {
+    for test in tests.iter() {
+        test();
+    }
+}
+
+#[test_case]
+fn should_panic() {
+    assert_eq!(1, 2);
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    unsafe { exit_qemu(ExitCode::Success); }
+    loop {}
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -213,21 +213,33 @@ where
 {
     let mut executable = None;
     let mut quiet = false;
+    let mut runner_args = None;
 
     let mut arg_iter = args.into_iter().fuse();
 
     loop {
-        match arg_iter.next().as_ref().map(|s| s.as_str()) {
-            Some("--help") | Some("-h") => {
+        if executable.is_some() {
+            let args: Vec<_> = arg_iter.collect();
+            if args.len() > 0 {
+                runner_args = Some(args);
+            }
+            break;
+        }
+        let next = match arg_iter.next() {
+            Some(next) => next,
+            None => break,
+        };
+        match next.as_str() {
+            "--help" | "-h" => {
                 return Ok(Command::RunnerHelp);
             }
-            Some("--version") => {
+            "--version" => {
                 return Ok(Command::Version);
             }
-            Some("--quiet") => {
+            "--quiet" => {
                 quiet = true;
             }
-            Some(exe) if executable.is_none() => {
+            exe => {
                 let path = Path::new(exe);
                 let path_canonicalized = path.canonicalize().map_err(|err| {
                     format!(
@@ -238,14 +250,13 @@ where
                 })?;
                 executable = Some(path_canonicalized);
             }
-            Some(arg) => Err(format!("unexpected argument `{}`", arg))?,
-            None => break,
         }
     }
 
     Ok(Command::Runner(RunnerArgs {
         executable: executable.ok_or("excepted path to kernel executable as first argument")?,
         quiet,
+        runner_args,
     }))
 }
 
@@ -254,4 +265,5 @@ pub struct RunnerArgs {
     pub executable: PathBuf,
     /// Suppress any output to stdout.
     pub quiet: bool,
+    pub runner_args: Option<Vec<String>>,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -240,15 +240,7 @@ where
                 quiet = true;
             }
             exe => {
-                let path = Path::new(exe);
-                let path_canonicalized = path.canonicalize().map_err(|err| {
-                    format!(
-                        "Failed to canonicalize executable path `{}`: {}",
-                        path.display(),
-                        err
-                    )
-                })?;
-                executable = Some(path_canonicalized);
+                executable = Some(PathBuf::from(exe));
             }
         }
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -170,14 +170,21 @@ impl Builder {
             let cargo_toml_content = fs::read_to_string(&bootloader_pkg.manifest_path)
                 .map_err(|err| format!("bootloader has no valid Cargo.toml: {}", err))
                 .map_err(CreateBootimageError::BootloaderInvalid)?;
-            let cargo_toml = cargo_toml_content.parse::<toml::Value>()
+            let cargo_toml = cargo_toml_content
+                .parse::<toml::Value>()
                 .map_err(|e| format!("Failed to parse Cargo.toml of bootloader: {}", e))
                 .map_err(CreateBootimageError::BootloaderInvalid)?;
             let metadata = cargo_toml.get("package").and_then(|t| t.get("metadata"));
-            let target = metadata.and_then(|t| t.get("bootloader")).and_then(|t| t.get("target"));
-            let target_str = target.and_then(|v| v.as_str()).ok_or(CreateBootimageError::BootloaderInvalid(
+            let target = metadata
+                .and_then(|t| t.get("bootloader"))
+                .and_then(|t| t.get("target"));
+            let target_str = target
+                .and_then(|v| v.as_str())
+                .ok_or(CreateBootimageError::BootloaderInvalid(
                 "No `package.metadata.bootloader.target` key found in Cargo.toml of bootloader\n\n\
-                    (If you're using the official bootloader crate, you need at least version 0.5.1)".into()))?;
+                 (If you're using the official bootloader crate, you need at least version 0.5.1)"
+                    .into(),
+            ))?;
             bootloader_root.join(target_str)
         };
         let bootloader_features =

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,9 @@ pub struct Config {
     pub test_args: Option<Vec<String>>,
     /// The timeout for running an test through `bootimage test` or `bootimage runner` in seconds
     pub test_timeout: u32,
+    /// An exit code that should be considered as success for test executables (applies to
+    /// `bootimage runner`)
+    pub test_success_exit_code: Option<i32>,
     non_exhaustive: (),
 }
 
@@ -72,6 +75,9 @@ pub(crate) fn read_config_inner(manifest_path: &Path) -> Result<Config, ErrorMes
             }
             ("test-timeout", Value::Integer(timeout)) => {
                 config.test_timeout = Some(timeout as u32);
+            }
+            ("test-success-exit-code", Value::Integer(exit_code)) => {
+                config.test_success_exit_code = Some(exit_code as i32);
             }
             ("run-command", Value::Array(array)) => {
                 let mut command = Vec::new();
@@ -120,6 +126,7 @@ struct ConfigBuilder {
     run_args: Option<Vec<String>>,
     test_args: Option<Vec<String>>,
     test_timeout: Option<u32>,
+    test_success_exit_code: Option<i32>,
 }
 
 impl Into<Config> for ConfigBuilder {
@@ -134,6 +141,7 @@ impl Into<Config> for ConfigBuilder {
             run_args: self.run_args,
             test_args: self.test_args,
             test_timeout: self.test_timeout.unwrap_or(60 * 5),
+            test_success_exit_code: self.test_success_exit_code,
             non_exhaustive: (),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ pub struct Config {
     pub run_command: Vec<String>,
     /// Additional arguments passed to the runner on `bootimage run` or `bootimage runner`
     pub run_args: Option<Vec<String>>,
-    /// The timeout for running an integration test through `bootimage test` in seconds
+    /// The timeout for running an test through `bootimage test` or `bootimage runner` in seconds
     pub test_timeout: u32,
     non_exhaustive: (),
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,9 @@ pub struct Config {
     ///
     /// The substring "{}" will be replaced with the path to the bootable disk image.
     pub run_command: Vec<String>,
-    /// Additional arguments passed to the runner on `bootimage run` or `bootimage runner`
+    /// Additional arguments passed to the runner for not-test binaries
+    ///
+    /// Applies to `bootimage run` and `bootimage runner`.
     pub run_args: Option<Vec<String>>,
     /// The timeout for running an test through `bootimage test` or `bootimage runner` in seconds
     pub test_timeout: u32,

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,10 @@ pub struct Config {
     ///
     /// Applies to `bootimage run` and `bootimage runner`.
     pub run_args: Option<Vec<String>>,
+    /// Additional arguments passed to the runner for test binaries
+    ///
+    /// Applies to `bootimage runner`.
+    pub test_args: Option<Vec<String>>,
     /// The timeout for running an test through `bootimage test` or `bootimage runner` in seconds
     pub test_timeout: u32,
     non_exhaustive: (),
@@ -89,6 +93,16 @@ pub(crate) fn read_config_inner(manifest_path: &Path) -> Result<Config, ErrorMes
                 }
                 config.run_args = Some(args);
             }
+            ("test-args", Value::Array(array)) => {
+                let mut args = Vec::new();
+                for value in array {
+                    match value {
+                        Value::String(s) => args.push(s),
+                        _ => Err(format!("test-args must be a list of strings"))?,
+                    }
+                }
+                config.test_args = Some(args);
+            }
             (key, value) => Err(format!(
                 "unexpected `package.metadata.bootimage` \
                  key `{}` with value `{}`",
@@ -104,6 +118,7 @@ struct ConfigBuilder {
     default_target: Option<String>,
     run_command: Option<Vec<String>>,
     run_args: Option<Vec<String>>,
+    test_args: Option<Vec<String>>,
     test_timeout: Option<u32>,
 }
 
@@ -117,6 +132,7 @@ impl Into<Config> for ConfigBuilder {
                 "format=raw,file={}".into(),
             ]),
             run_args: self.run_args,
+            test_args: self.test_args,
             test_timeout: self.test_timeout.unwrap_or(60 * 5),
             non_exhaustive: (),
         }

--- a/src/help/mod.rs
+++ b/src/help/mod.rs
@@ -33,5 +33,6 @@ pub(crate) fn test_help() {
 
 pub(crate) fn no_subcommand() -> ErrorMessage {
     "Please invoke `bootimage` with a subcommand (e.g. `bootimage build`).\n\n\
-    See `bootimage --help` for more information.".into()
+     See `bootimage --help` for more information."
+        .into()
 }

--- a/src/help/run_help.txt
+++ b/src/help/run_help.txt
@@ -19,6 +19,5 @@ CONFIGURATION:
     # The command invoked on `bootimage run` or `bootimage runner`
     # (the "{}" will be replaced with the path to the bootable disk image)
     run-command = ["qemu-system-x86_64", "-drive", "format=raw,file={}"]
-    # Additional arguments passed to the runner on `bootimage run` or `bootimage runner`
-    # (this is useful when you want to add some arguments to the default QEMU command)
+    # Additional arguments passed to the run command for non-test executables
     run-args = []

--- a/src/help/run_help.txt
+++ b/src/help/run_help.txt
@@ -16,8 +16,8 @@ CONFIGURATION:
     following options are available to configure run behavior:
 
     [package.metadata.bootimage]
-    # The command invoked on `bootimage run` or `bootimage runner`
-    # (the "{}" will be replaced with the path to the bootable disk image)
+    # The command invoked with the created bootimage (the "{}" will be replaced
+    # with the path to the bootable disk image)
     run-command = ["qemu-system-x86_64", "-drive", "format=raw,file={}"]
     # Additional arguments passed to the run command for non-test executables
     run-args = []

--- a/src/help/runner_help.txt
+++ b/src/help/runner_help.txt
@@ -22,7 +22,7 @@ CONFIGURATION:
     # The command invoked on `bootimage run` or `bootimage runner`
     # (the "{}" will be replaced with the path to the bootable disk image)
     run-command = ["qemu-system-x86_64", "-drive", "format=raw,file={}"]
-    # Additional arguments passed to the runner on `bootimage run` or `bootimage runner`
-    # (this is useful when you want to add some arguments to the default QEMU command)
-    run-args = []    # The timeout for running a test (in seconds)
+    # Additional arguments passed to the run command for non-test executables
+    run-args = []
+    # The timeout for running a test (in seconds)
     test-timeout = 300

--- a/src/help/runner_help.txt
+++ b/src/help/runner_help.txt
@@ -24,4 +24,5 @@ CONFIGURATION:
     run-command = ["qemu-system-x86_64", "-drive", "format=raw,file={}"]
     # Additional arguments passed to the runner on `bootimage run` or `bootimage runner`
     # (this is useful when you want to add some arguments to the default QEMU command)
-    run-args = []
+    run-args = []    # The timeout for running a test (in seconds)
+    test-timeout = 300

--- a/src/help/runner_help.txt
+++ b/src/help/runner_help.txt
@@ -26,5 +26,7 @@ CONFIGURATION:
     run-args = []
     # Additional arguments passed to the run command for test executables
     test-args = []
+    # An exit code that should be considered as success for test executables
+    test-success-exit-code = {integer}
     # The timeout for running a test (in seconds)
     test-timeout = 300

--- a/src/help/runner_help.txt
+++ b/src/help/runner_help.txt
@@ -1,7 +1,7 @@
 Creates a bootable disk image from a Rust kernel and launches it in QEMU
 
 USAGE:
-    bootimage runner EXECUTABLE        Convert and run the given EXECUTABLE
+    bootimage runner EXECUTABLE [ARGS]    Convert and run the given EXECUTABLE
 
     (for other forms of usage see `bootimage --help`)
 
@@ -10,6 +10,8 @@ USAGE:
         [target.'cfg(target_os = "none")']
         runner = "bootimage runner"
     ```
+
+    All ARGS are passed to the run command.
 
 CONFIGURATION:
     The behavior of `bootimage runner` can be configured through a

--- a/src/help/runner_help.txt
+++ b/src/help/runner_help.txt
@@ -24,5 +24,7 @@ CONFIGURATION:
     run-command = ["qemu-system-x86_64", "-drive", "format=raw,file={}"]
     # Additional arguments passed to the run command for non-test executables
     run-args = []
+    # Additional arguments passed to the run command for test executables
+    test-args = []
     # The timeout for running a test (in seconds)
     test-timeout = 300

--- a/src/help/runner_help.txt
+++ b/src/help/runner_help.txt
@@ -19,8 +19,8 @@ CONFIGURATION:
     following options are available to configure run behavior:
 
     [package.metadata.bootimage]
-    # The command invoked on `bootimage run` or `bootimage runner`
-    # (the "{}" will be replaced with the path to the bootable disk image)
+    # The command invoked with the created bootimage (the "{}" will be replaced
+    # with the path to the bootable disk image)
     run-command = ["qemu-system-x86_64", "-drive", "format=raw,file={}"]
     # Additional arguments passed to the run command for non-test executables
     run-args = []

--- a/src/subcommand/build.rs
+++ b/src/subcommand/build.rs
@@ -37,4 +37,3 @@ pub(crate) fn build_impl(
 
     Ok(bootimages)
 }
-

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -9,14 +9,19 @@ pub(crate) fn run(mut args: Args) -> Result<i32, ErrorMessage> {
     args.apply_default_target(&config, builder.kernel_root());
 
     if args.bin_name().is_none() {
-        let kernel_package = builder.kernel_package()
+        let kernel_package = builder
+            .kernel_package()
             .map_err(|key| format!("Kernel package not found it cargo metadata (`{}`)", key))?;
         let bins = kernel_package.targets.iter().filter(|t| t.kind == ["bin"]);
         let mut not_test = bins.filter(|t| !t.name.starts_with("test-"));
-        let bin_name = not_test.next().ok_or("no kernel executable found")?.name.to_owned();
+        let bin_name = not_test
+            .next()
+            .ok_or("no kernel executable found")?
+            .name
+            .to_owned();
         if not_test.count() > 0 {
             Err("Multiple kernel executables found. \
-            Please specify the binary you want to run as a `--bin` argument")?;
+                 Please specify the binary you want to run as a `--bin` argument")?;
         }
         args.set_bin_name(bin_name);
     }

--- a/src/subcommand/runner.rs
+++ b/src/subcommand/runner.rs
@@ -35,7 +35,11 @@ pub(crate) fn runner(args: RunnerArgs) -> Result<i32, ErrorMessage> {
         .iter()
         .map(|arg| arg.replace("{}", &format!("{}", bootimage_bin.display())))
         .collect();
-    if !is_test {
+    if is_test {
+        if let Some(args) = config.test_args {
+            run_command.extend(args);
+        }
+    } else {
         if let Some(args) = config.run_args {
             run_command.extend(args);
         }

--- a/src/subcommand/runner.rs
+++ b/src/subcommand/runner.rs
@@ -28,6 +28,9 @@ pub(crate) fn runner(args: RunnerArgs) -> Result<i32, ErrorMessage> {
     if let Some(run_args) = config.run_args {
         command.args(run_args);
     }
+    if let Some(args) = args.runner_args {
+        command.args(args);
+    }
 
     println!("Running: {:?}", command);
 

--- a/src/subcommand/runner.rs
+++ b/src/subcommand/runner.rs
@@ -42,7 +42,9 @@ pub(crate) fn runner(args: RunnerArgs) -> Result<i32, ErrorMessage> {
         run_command.extend(args);
     }
 
-    println!("Running: `{}`", run_command.join(" "));
+    if !args.quiet {
+        println!("Running: `{}`", run_command.join(" "));
+    }
     let mut command = process::Command::new(&run_command[0]);
     command.args(&run_command[1..]);
 

--- a/src/subcommand/runner.rs
+++ b/src/subcommand/runner.rs
@@ -35,8 +35,10 @@ pub(crate) fn runner(args: RunnerArgs) -> Result<i32, ErrorMessage> {
         .iter()
         .map(|arg| arg.replace("{}", &format!("{}", bootimage_bin.display())))
         .collect();
-    if let Some(args) = config.run_args {
-        run_command.extend(args);
+    if !is_test {
+        if let Some(args) = config.run_args {
+            run_command.extend(args);
+        }
     }
     if let Some(args) = args.runner_args {
         run_command.extend(args);


### PR DESCRIPTION
Changelog:

- Pass additional arguments to the run command (e.g. QEMU)
- Consider all binaries in the `target/deps` folder as test executables
- Apply `test-timeout` config key when running tests in `bootimage runner`
- Don't apply `run-args` for test executables
- Add a new `test-args` config key for test arguments
- Add a new `test-success-exit-code` config key for interpreting an exit code as success
   - This is useful when the `isa-debug-exit` QEMU device is used.
- Improve printing of the run command (print string instead of array, print non-canonicalized executable path, respect `--quiet`)