### PR TITLE
Set XBUILD_SYSROOT_PATH when building bootloader

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -222,7 +222,7 @@ impl Builder {
             cmd.arg("--release");
             cmd.env("KERNEL", kernel_bin_path);
             cmd.env_remove("RUSTFLAGS");
-            cmd.env("SYSROOT_DIR", target_dir.join("sysroot")); // for cargo-xbuild
+            cmd.env("XBUILD_SYSROOT_PATH", target_dir.join("bootloader-sysroot")); // for cargo-xbuild
             cmd
         };
 


### PR DESCRIPTION
The `XBUILD_SYSROOT_PATH` environment variable controls where `cargo-xbuild` should create the custom sysroot. This PR sets the variable to `target/bootloader-sysroot` when building the bootloader. 

The previous behavior was to create the sysroot in a `target/sysroot` directory under the bootloader source directory, which is normally a folder in the local cargo package registry (under `~/.cargo`). Modifying the content of this folder does not seem like a good idea. It also caused problems when the `.cargo` folder lives under a path that contains spaces due to https://github.com/rust-lang/cargo/issues/6139.

This PR also unset the `SYSROOT_DIR` environment variable which seems unused.

A side effect of this change is that it should fix the CI build. It was broken for a few days because Azure Pipelines now includes rustup in its Windows image, so that the `.cargo` folder lives under `Program Files`, which leads to a sysroot path with spaces when building the bootloader without the `XBUILD_SYSROOT_PATH` variable.