### PR TITLE
If the bootloader has a feature named `binary`, enable it

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ First you need to add a dependency on the [`bootloader`](https://github.com/rust
 # in your Cargo.toml
 
 [dependencies]
-bootloader = "0.5.1"
+bootloader = "0.6.4"
 ```
 
 **Note**: At least bootloader version `0.5.1` is required since `bootimage 0.7.0`. For earlier bootloader versions, use `bootimage 0.6.6`.

--- a/example-kernels/Cargo.lock
+++ b/example-kernels/Cargo.lock
@@ -13,7 +13,7 @@ name = "basic"
 version = "0.1.0"
 dependencies = [
  "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -23,7 +23,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -32,7 +32,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "font8x8 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "font8x8 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "llvm-tools 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -40,8 +40,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cc"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -49,7 +54,7 @@ name = "default-target-bootimage"
 version = "0.1.0"
 dependencies = [
  "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -57,7 +62,7 @@ name = "default-target-cargo"
 version = "0.1.0"
 dependencies = [
  "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -70,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "font8x8"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -80,7 +85,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "getopts"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -96,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.51"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -119,7 +124,7 @@ name = "pulldown-cmark"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -128,7 +133,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -152,8 +157,8 @@ name = "raw-cpuid"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -167,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -178,7 +183,7 @@ name = "runner"
 version = "0.1.0"
 dependencies = [
  "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -186,7 +191,7 @@ name = "runner-test"
 version = "0.1.0"
 dependencies = [
  "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -235,7 +240,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -243,7 +248,7 @@ name = "testing-qemu-exit-code"
 version = "0.1.0"
 dependencies = [
  "bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -254,7 +259,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "uart_16550 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -262,7 +267,7 @@ name = "uart_16550"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -306,7 +311,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ux 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -319,7 +324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "array-init 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ux 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -327,14 +332,14 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "array-init 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "usize_conversions 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ux 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -354,15 +359,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum array-init 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
 "checksum bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
-"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum bootloader 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a8f7c11b70b5781deec899276f7d67611eaf296a8bd7dcc9b9d37c71a5389c52"
-"checksum cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83"
+"checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
+"checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7c6c16d316ccdac21a4dd648e314e76facbbaf316e83ca137d0857a9c07419d0"
-"checksum font8x8 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b81d84c3c978af7d05d31a2198af4b9ba956d819d15d8f6d58fc150e33f8dc1f"
+"checksum font8x8 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "44226c40489fb1d602344a1d8f1b544570c3435e396dda1eda7b5ef010d8f1be"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-"checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
+"checksum getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "72327b15c228bfe31f1390f93dd5e9279587f0463836393c9df719ce62a3e450"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
-"checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
+"checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"
 "checksum llvm-tools 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "955be5d0ca0465caf127165acb47964f911e2bc26073e865deb8be7189302faf"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "66481dbeb5e773e7bd85b63cd6042c30786f834338288c5ec4f3742673db360a"
@@ -372,7 +378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
 "checksum raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "30a9d219c32c9132f7be513c18be77c9881c7107d2ab5569d205a6a0f0e6dc7d"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
@@ -389,6 +395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum x86_64 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd647af1614659e1febec1d681231aea4ebda4818bf55a578aff02f3e4db4b4"
 "checksum x86_64 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f9258d7e2dd25008d69e8c9e9ee37865887a5e1e3d06a62f1cb3f6c209e6f177"
-"checksum x86_64 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0a8201f52d2c7b373c7243dcdfb27c0dd5012f221ef6a126f507ee82005204"
+"checksum x86_64 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bb8f09c32a991cc758ebcb9b7984f530095d32578a4e7b85db6ee1f0bbe4c9c6"
 "checksum xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22678df5df766e8d1e5d609da69f0c3132d794edf6ab5e75e7abcd2270d4cf58"
 "checksum zero 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f1bc8a6b2005884962297587045002d8cfb8dcec9db332f4ca216ddc5de82c5"

--- a/example-kernels/basic/Cargo.toml
+++ b/example-kernels/basic/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = "0.5.1"
+bootloader = "0.6.4"
 x86_64 = "0.5.3"

--- a/example-kernels/default-target-bootimage/Cargo.toml
+++ b/example-kernels/default-target-bootimage/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = "0.5.1"
+bootloader = "0.6.4"
 x86_64 = "0.5.3"
 
 [package.metadata.bootimage]

--- a/example-kernels/default-target-cargo/Cargo.toml
+++ b/example-kernels/default-target-cargo/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = "0.5.1"
+bootloader = "0.6.4"
 x86_64 = "0.5.3"

--- a/example-kernels/runner-test/Cargo.toml
+++ b/example-kernels/runner-test/Cargo.toml
@@ -9,7 +9,7 @@ name = "no-harness"
 harness = false
 
 [dependencies]
-bootloader = "0.5.1"
+bootloader = "0.6.4"
 x86_64 = "0.5.3"
 
 [package.metadata.bootimage]

--- a/example-kernels/runner/Cargo.toml
+++ b/example-kernels/runner/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = "0.5.1"
+bootloader = "0.6.4"
 x86_64 = "0.5.3"
 
 [package.metadata.bootimage]

--- a/example-kernels/testing-qemu-exit-code/Cargo.toml
+++ b/example-kernels/testing-qemu-exit-code/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = "0.5.1"
+bootloader = "0.6.4"
 x86_64 = "0.5.3"
 
 [package.metadata.bootimage]

--- a/example-kernels/testing-serial-result/Cargo.toml
+++ b/example-kernels/testing-serial-result/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = "0.5.1"
+bootloader = "0.6.4"
 x86_64 = "0.5.3"
 spin = "0.4.9"
 uart_16550 = "0.1.0"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -311,8 +311,8 @@ impl Builder {
         // Pad to nearest block size
         {
             const BLOCK_SIZE: u64 = 512;
-            use std::fs::{File, OpenOptions};
-            let mut file = OpenOptions::new()
+            use std::fs::OpenOptions;
+            let file = OpenOptions::new()
                 .write(true)
                 .open(&output_bin_path)
                 .map_err(|err| CreateBootimageError::Io {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -225,6 +225,7 @@ impl Builder {
             cmd.arg("xbuild");
             cmd.arg("--manifest-path");
             cmd.arg(&bootloader_pkg.manifest_path);
+            cmd.arg("--bin").arg(&bootloader_name);
             cmd.arg("--target-dir").arg(&target_dir);
             cmd.arg("--features")
                 .arg(bootloader_features.as_slice().join(" "));

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -410,7 +410,11 @@ impl fmt::Display for BuildKernelError {
                     Run `cargo install cargo-xbuild` to install it.")
             }
             BuildKernelError::XbuildFailed{stderr} => {
-                writeln!(f, "Kernel build failed:\n{}", String::from_utf8_lossy(stderr))
+                writeln!(f, "Kernel build failed")?;
+                if !stderr.is_empty() {
+                    writeln!(f, "\n{}", String::from_utf8_lossy(stderr))?;
+                }
+                Ok(())
             }
             BuildKernelError::XbuildJsonOutputInvalidUtf8(err) => {
                 writeln!(f, "Output of kernel build with --message-format=json is not valid UTF-8:\n{}", err)
@@ -481,11 +485,13 @@ impl fmt::Display for CreateBootimageError {
                 "The `bootloader` dependency has not the right format: {}",
                 err
             ),
-            CreateBootimageError::BootloaderBuildFailed { stderr } => writeln!(
-                f,
-                "Bootloader build failed:\n\n{}",
-                String::from_utf8_lossy(stderr)
-            ),
+            CreateBootimageError::BootloaderBuildFailed { stderr } => {
+                writeln!(f, "Bootloader build failed")?;
+                if !stderr.is_empty() {
+                    writeln!(f, "\n{}", String::from_utf8_lossy(stderr))?;
+                }
+                Ok(())
+            }
             CreateBootimageError::Io { message, error } => {
                 writeln!(f, "I/O error: {}: {}", message, error)
             }


### PR DESCRIPTION
This allows the bootloader to define dependencies that only apply to the main.rs (not the lib.rs), in order to reduce compile times. See https://github.com/rust-lang/cargo/issues/1982#issuecomment-319661478 for more information.