### PR TITLE
Add options for phys mem offset, kernel stack addr and size

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -76,6 +76,18 @@ Configuration is done through a through a `[package.metadata.bootimage]` table i
     # Applies to `bootimage run` and `bootimage runner`
     run-args = []
 
+    # The offset used for mapping physical memory when the `map_physical_memory` feature of the
+    # bootloader crate is enabled. Must be given as a string, as TOML does not support unsigned
+    # 64-bit integers.
+    physical-memory-offset = ""
+
+    # The virtual address where the kernel's stack should be placed. Must be given as a string,
+    # as TOML does not support unsigned 64-bit integers.
+    kernel-stack-address = ""
+
+    # The size of the kernel's stack, in number of 4KiB pages.
+    kernel-stack-size = 512
+
     # Additional arguments passed to the run command for test executables
     # Applies to `bootimage runner`
     test-args = []

--- a/src/subcommand/build.rs
+++ b/src/subcommand/build.rs
@@ -1,10 +1,9 @@
-use crate::{args::Args, builder::Builder, config, ErrorMessage};
+use crate::{args::Args, builder::Builder, ErrorMessage};
 use std::path::PathBuf;
 
 pub(crate) fn build(mut args: Args) -> Result<(), ErrorMessage> {
     let builder = Builder::new(args.manifest_path().clone())?;
-    let config = config::read_config(builder.kernel_manifest_path())?;
-    args.apply_default_target(&config, builder.kernel_root());
+    args.apply_default_target(builder.kernel_config(), builder.kernel_root());
 
     let quiet = args.quiet;
     build_impl(&builder, &mut args, quiet).map(|_| ())

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -1,12 +1,12 @@
-use crate::{args::Args, builder::Builder, config, ErrorMessage};
+use crate::{args::Args, builder::Builder, ErrorMessage};
 use std::process;
 
 pub(crate) fn run(mut args: Args) -> Result<i32, ErrorMessage> {
     use crate::subcommand::build;
 
     let builder = Builder::new(args.manifest_path().clone())?;
-    let config = config::read_config(builder.kernel_manifest_path())?;
-    args.apply_default_target(&config, builder.kernel_root());
+    let config = builder.kernel_config();
+    args.apply_default_target(config, builder.kernel_root());
 
     if args.bin_name().is_none() {
         let kernel_package = builder
@@ -45,7 +45,7 @@ pub(crate) fn run(mut args: Args) -> Result<i32, ErrorMessage> {
             ),
         );
     }
-    if let Some(run_args) = config.run_args {
+    if let Some(run_args) = &config.run_args {
         command.args(run_args);
     }
     command.args(&args.run_args);

--- a/src/subcommand/runner.rs
+++ b/src/subcommand/runner.rs
@@ -1,10 +1,10 @@
-use crate::{args::RunnerArgs, builder::Builder, config, ErrorMessage};
+use crate::{args::RunnerArgs, builder::Builder, ErrorMessage};
 use std::{process, time::Duration};
 use wait_timeout::ChildExt;
 
 pub(crate) fn runner(args: RunnerArgs) -> Result<i32, ErrorMessage> {
     let builder = Builder::new(None)?;
-    let config = config::read_config(builder.kernel_manifest_path())?;
+    let config = builder.kernel_config();
     let exe_parent = args
         .executable
         .parent()
@@ -36,12 +36,12 @@ pub(crate) fn runner(args: RunnerArgs) -> Result<i32, ErrorMessage> {
         .map(|arg| arg.replace("{}", &format!("{}", bootimage_bin.display())))
         .collect();
     if is_test {
-        if let Some(args) = config.test_args {
-            run_command.extend(args);
+        if let Some(args) = &config.test_args {
+            run_command.extend(args.clone());
         }
     } else {
-        if let Some(args) = config.run_args {
-            run_command.extend(args);
+        if let Some(args) = &config.run_args {
+            run_command.extend(args.clone());
         }
     }
     if let Some(args) = args.runner_args {

--- a/src/subcommand/test.rs
+++ b/src/subcommand/test.rs
@@ -1,12 +1,12 @@
-use crate::{args::Args, builder::Builder, config, subcommand::build, ErrorMessage};
+use crate::{args::Args, builder::Builder, subcommand::build, ErrorMessage};
 use rayon::prelude::*;
 use std::{fs, io, io::Write, process, time::Duration};
 use wait_timeout::ChildExt;
 
 pub(crate) fn test(mut args: Args) -> Result<(), ErrorMessage> {
     let builder = Builder::new(args.manifest_path().clone())?;
-    let config = config::read_config(builder.kernel_manifest_path())?;
-    args.apply_default_target(&config, builder.kernel_root());
+    let config = builder.kernel_config();
+    args.apply_default_target(config, builder.kernel_root());
 
     let test_args = args.clone();
 


### PR DESCRIPTION
Allows you to specify these three options through Cargo.toml:

```toml
[package.metadata.bootimage]
physical-memory-offset = "0xffff800000000000"
kernel-stack-address = "0xffffff8000000000"
kernel-stack-size = 128
```