### PR TITLE
Don't exit with expected exit code when failed to read QEMU exit code

### DIFF
--- a/src/subcommand/runner.rs
+++ b/src/subcommand/runner.rs
@@ -73,6 +73,15 @@ pub(crate) fn runner(args: RunnerArgs) -> Result<i32, ErrorMessage> {
                 return Err(ErrorMessage::from("Timed Out"));
             }
             Some(exit_status) => {
+                #[cfg(unix)]
+                {
+                    if exit_status.code().is_none() {
+                        use std::os::unix::process::ExitStatusExt;
+                        if let Some(signal) = exit_status.signal() {
+                            eprintln!("QEMU process was terminated by signal {}", signal);
+                        }
+                    }
+                }
                 let qemu_exit_code = exit_status.code().ok_or("Failed to read QEMU exit code")?;
                 match config.test_success_exit_code {
                     Some(code) if qemu_exit_code == code => 0,

--- a/src/subcommand/runner.rs
+++ b/src/subcommand/runner.rs
@@ -72,10 +72,13 @@ pub(crate) fn runner(args: RunnerArgs) -> Result<i32, ErrorMessage> {
                     .map_err(|e| format!("Failed to wait for QEMU process: {}", e))?;
                 return Err(ErrorMessage::from("Timed Out"));
             }
-            Some(exit_status) => match config.test_success_exit_code {
-                Some(code) if exit_status.code() == Some(code) => 0,
-                other => other.unwrap_or(1),
-            },
+            Some(exit_status) => {
+                let qemu_exit_code = exit_status.code().ok_or("Failed to read QEMU exit code")?;
+                match config.test_success_exit_code {
+                    Some(code) if qemu_exit_code == code => 0,
+                    _ => qemu_exit_code,
+                }
+            }
         }
     } else {
         let status = command


### PR DESCRIPTION
If failed to read the QEMU exit code, bootimage exits with the expected exit code specified in the `test-success-exit-code` config key. Instead, it should report an error when failing to read the QEMU exit code and never exit with the expected exit code.

Reported in https://github.com/phil-opp/blog_os/issues/591#issuecomment-549050272

Thanks to @jos-b and @bjorn3 for reporting and helping with debugging!