### PR TITLE
Set empty RUSTFLAGS to ensure that no .cargo/config applies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
         image_name: 'ubuntu-16.04'
         rustup_toolchain: stable
       mac:
-        image_name: 'macos-10.13'
+        image_name: 'macOS-10.15'
         rustup_toolchain: stable
       windows:
         image_name: 'vs2017-win2016'
@@ -75,7 +75,7 @@ jobs:
         image_name: 'ubuntu-16.04'
         rustup_toolchain: nightly
       mac:
-        image_name: 'macos-10.13'
+        image_name: 'macos-10.15'
         rustup_toolchain: nightly
       windows:
         image_name: 'vs2017-win2016'

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -233,7 +233,7 @@ impl Builder {
             cmd.arg("--release");
             cmd.env("KERNEL", kernel_bin_path);
             cmd.env("KERNEL_MANIFEST", &self.kernel_manifest_path);
-            cmd.env_remove("RUSTFLAGS");
+            cmd.env("RUSTFLAGS", "");
             cmd.env("XBUILD_SYSROOT_PATH", target_dir.join("bootloader-sysroot")); // for cargo-xbuild
             cmd
         };

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -477,10 +477,11 @@ impl fmt::Display for CreateBootimageError {
                 "Could not find required key `{}` in cargo metadata output",
                 key
             ),
-            CreateBootimageError::BootloaderNotFound => {
-                writeln!(f, "Bootloader dependency not found\n\n\
-                    You need to add a dependency on a crate named `bootloader` in your Cargo.toml.")
-            }
+            CreateBootimageError::BootloaderNotFound => writeln!(
+                f,
+                "Bootloader dependency not found\n\n\
+                    You need to add a dependency on a crate named `bootloader` in your Cargo.toml."
+            ),
             CreateBootimageError::BootloaderInvalid(err) => writeln!(
                 f,
                 "The `bootloader` dependency has not the right format: {}",


### PR DESCRIPTION
Without the `RUSTFLAGS` environment variable set, cargo looks at `.cargo/config` files in all parent directories. Such a file can contain a `build.rustflags` key that would then be applied to the bootloader build too. Since some rustflags can break the build (e.g. `-C target-cpu=native`), we should prevent that.

Creating a `cargo/.config` file with an empty `build.rustflags` key in the bootloader repository does not suffice for fixing this because cargo unifies arrays with the values defined in parent directories. So the only way to ensure that no rustflags are passed is to set the RUSTFLAGS environment variable to the empty string, exploiting the fact that it takes precedence over any `build.rustflags` key.

Fixes https://github.com/phil-opp/blog_os/issues/770
