### PR TITLE
Add support for workspace subcrate building

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,6 +85,11 @@ Configuration is done through a through a `[package.metadata.bootimage]` table i
 
     # The timeout for running a test through `bootimage test` or `bootimage runner` (in seconds)
     test-timeout = 300
+
+    # If your root crate is a workspace, and the crate you wish to compile as
+    # the kernel is a subcrate of that workspace, specifying that subcrate's
+    # name here will build that crate when `bootimage` is run from the root
+    workspace-subcrate = "example-kernel-amd64"
 ```
 
 ## License

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,9 @@ pub struct Config {
     /// An exit code that should be considered as success for test executables (applies to
     /// `bootimage runner`)
     pub test_success_exit_code: Option<i32>,
+    /// The workspace subcrate to use for `bootimage` runs. This should be specified in the
+    /// workspace's `Cargo.toml`, pointing to a crate that is a member of the workspace.
+    pub workspace_subcrate: Option<String>,
     non_exhaustive: (),
 }
 
@@ -109,6 +112,7 @@ pub(crate) fn read_config_inner(manifest_path: &Path) -> Result<Config, ErrorMes
                 }
                 config.test_args = Some(args);
             }
+            ("workspace-subcrate", Value::String(s)) => config.workspace_subcrate = From::from(s),
             (key, value) => Err(format!(
                 "unexpected `package.metadata.bootimage` \
                  key `{}` with value `{}`",
@@ -127,6 +131,7 @@ struct ConfigBuilder {
     test_args: Option<Vec<String>>,
     test_timeout: Option<u32>,
     test_success_exit_code: Option<i32>,
+    workspace_subcrate: Option<String>,
 }
 
 impl Into<Config> for ConfigBuilder {
@@ -142,6 +147,7 @@ impl Into<Config> for ConfigBuilder {
             test_args: self.test_args,
             test_timeout: self.test_timeout.unwrap_or(60 * 5),
             test_success_exit_code: self.test_success_exit_code,
+            workspace_subcrate: self.workspace_subcrate,
             non_exhaustive: (),
         }
     }


### PR DESCRIPTION
This pull request adds the configuration key `workspace-subcrate` to the `package.metadata.bootimage` table, which lets the root crate specify a subcrate within it's workspace to build as the kernel executable, instead of the root crate itself.

This arose out of my OS project, where the root crate ("os-core") is platform-agnostic, and there is a subcrate ("os-amd64") that contains the target-specific things. The "os-amd64" crate is the one with the `bootsector` dependency, and contains the `entry_point!()` definition.

The idea here is to allow running `bootimage` from the root of the repository, which is where all the other Cargo operations get run from (`cargo fmt`, `cargo doc`, etc), and still have everything work.

As an example, the Cargo manifest of the root crate would have it's metadata set ilke the following:

```toml
[package.metadata.bootimage]
workspace-subcrate = "os-amd64"
```

The "os-amd64" crate (which is expected to be in a direct subdirectory of the root crate) would then have it's manifest specify `bootimage` options as normal (like setting the default target, QEMU args, etc).

A limitation of using the `package.metadata.bootimage` manifest table for this is that a top-level pure workspace manifest can not specify a subcrate to use as the kernel executable crate, since we're using a subtable of `package` to store the configuration (which makes `cargo-metadata` freak out since there's not actually a valid package definition there). A possible solution to this is to duplicate a lot of the configuration logic and parse a `workspace.metadata` subtable, however IIRC `workspace.metadata` is not a standard key so that may cause some other things to go wrong.

A possible addition to this is to walk up the directory hierarchy looking for Cargo manifests (much the same as the `locate-cargo-manifest` crate does) looking for the highest level crate manifest containing a `package.metadata.bootimage` table, and treating that as the crate root (and then descending again should the `workspace-subcrate` key be found), which would allow running `bootimage` from anywhere within the repository tree and still having everything work - much the same as running `bootimage` currently from a subdirectory in a single-package repository works currently.

I will add tests for this functionality should the maintainers wish to merge this PR.