### PR TITLE
Add support for building bootloaders using `-Zbuild-std`

### DIFF
--- a/src/builder/bootloader.rs
+++ b/src/builder/bootloader.rs
@@ -60,17 +60,10 @@ impl BuildConfig {
                 .and_then(|t| t.get("bootloader"))
                 .and_then(|t| t.get("build-std"));
             if let Some(key) = key {
-                Some(
-                    key.as_str()
-                        .ok_or_else(|| {
-                            BootloaderError::BootloaderInvalid(
-                        "A non-string `package.metadata.bootloader.build-std` key found in \
-                    Cargo.toml of bootloader"
-                            .into(),
-                    )
-                        })?
-                        .into(),
-                )
+                let err_msg = "A non-string `package.metadata.bootloader.build-std` key found in \
+                Cargo.toml of bootloader";
+                let err = || BootloaderError::BootloaderInvalid(err_msg.into());
+                Some(key.as_str().ok_or_else(err)?.into())
             } else {
                 None
             }


### PR DESCRIPTION
Bootloaders can opt-in to the new functionality by setting a `package.metadata.bootloader.build-std` key with a comma-separated string of sysroot crates that should be built. For example, a setting of `build-std = "core"` results in the build command `cargo build -Zbuild-std=core`.

If no such key is set, bootimage continues to compile the bootloader using the command `cargo xbuild`.