### PR TITLE
Make `cargo bootimage` use `cargo build` instead of `cargo xbuild`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,6 @@ jobs:
 
     - name: "Install Rustup Components"
       run: rustup component add rust-src llvm-tools-preview
-    - name: "Install cargo-xbuild"
-      run: cargo install cargo-xbuild --debug
 
      # install QEMU
     - name: Install QEMU (Linux)
@@ -103,20 +101,20 @@ jobs:
       shell: bash {0}
       working-directory: example-kernels
 
-    - name: 'Run `cargo xrun` for "runner" kernel'
+    - name: 'Run `cargo run` for "runner" kernel'
       run: |
-        cargo xrun
+        cargo run
         if [ $? -eq 109 ]; then (exit 0); else (exit 1); fi
       shell: bash {0}
       working-directory: example-kernels/runner
 
-    - run: cargo xtest
+    - run: cargo test
       working-directory: example-kernels/runner-test
-      name: 'Run `cargo xtest` for "runner-test" kernel'
+      name: 'Run `cargo test` for "runner-test" kernel'
 
-    - run: cargo xtest -Z doctest-xcompile
+    - run: cargo test -Z doctest-xcompile
       working-directory: example-kernels/runner-doctest
-      name: 'Run `cargo xtest -Z doctest-xcompile` for "runner-doctest" kernel'
+      name: 'Run `cargo test -Z doctest-xcompile` for "runner-doctest" kernel'
 
   check_formatting:
     name: "Check Formatting"

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@ Now you can build the kernel project and create a bootable disk image from it by
 cargo bootimage --target your_custom_target.json [other_args]
 ```
 
-The command will invoke [`cargo xbuild`](https://github.com/rust-osdev/cargo-xbuild), forwarding all passed options. Then it will build the specified bootloader together with the kernel to create a bootable disk image.
+The command will invoke `cargo build`, forwarding all passed options. Then it will build the specified bootloader together with the kernel to create a bootable disk image.
 
 ### Running
 
@@ -60,6 +60,10 @@ Configuration is done through a through a `[package.metadata.bootimage]` table i
 
 ```toml
 [package.metadata.bootimage]
+# The cargo subcommand that will be used for building the kernel.
+#
+# For building using the `cargo-xbuild` crate, set this to `xbuild`.
+build-command = ["build"]
 # The command invoked with the created bootimage (the "{}" will be replaced
 # with the path to the bootable disk image)
 # Applies to `bootimage run` and `bootimage runner`

--- a/example-kernels/.cargo/config.toml
+++ b/example-kernels/.cargo/config.toml
@@ -1,0 +1,2 @@
+[unstable]
+build-std = ["core", "compiler_builtins"]

--- a/example-kernels/Cargo.lock
+++ b/example-kernels/Cargo.lock
@@ -4,7 +4,7 @@
 name = "basic"
 version = "0.1.0"
 dependencies = [
- "bootloader 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -20,14 +20,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bootloader"
-version = "0.9.3"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rlibc"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "runner"
 version = "0.1.0"
 dependencies = [
- "bootloader 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -35,7 +43,7 @@ dependencies = [
 name = "runner-doctest"
 version = "0.1.0"
 dependencies = [
- "bootloader 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -43,7 +51,7 @@ dependencies = [
 name = "runner-test"
 version = "0.1.0"
 dependencies = [
- "bootloader 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -59,5 +67,6 @@ dependencies = [
 [metadata]
 "checksum bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
-"checksum bootloader 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "44ac0bdf4930c3c4d7f0d04eb6f15d7dcb9d5972b1ff9cd2bee0128112260fc7"
+"checksum bootloader 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1e54086033cef68ed4b1729aeb1383a4d2e7d9bacd70db747a0a0bc0a420c831"
+"checksum rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 "checksum x86_64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "365de37eb7c6da582cbb510dd0f3f1235d24ff6309a8a96e8a9909cc9bfd608f"

--- a/example-kernels/basic/Cargo.toml
+++ b/example-kernels/basic/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = "0.9.3"
+bootloader = "0.9.7"
 x86_64 = "0.11.0"

--- a/example-kernels/runner-doctest/Cargo.toml
+++ b/example-kernels/runner-doctest/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 bootloader = "0.9.7"
 x86_64 = "0.11.0"
+rlibc = "1.0.0"
 
 [package.metadata.bootimage]
 test-success-exit-code = 33 # (0x10 << 1) | 1

--- a/example-kernels/runner-doctest/Cargo.toml
+++ b/example-kernels/runner-doctest/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = "0.9.3"
+bootloader = "0.9.7"
 x86_64 = "0.11.0"
 
 [package.metadata.bootimage]

--- a/example-kernels/runner-doctest/src/lib.rs
+++ b/example-kernels/runner-doctest/src/lib.rs
@@ -4,6 +4,8 @@
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
+extern crate rlibc;
+
 /// add two numbers
 ///
 /// ```

--- a/example-kernels/runner-test/Cargo.toml
+++ b/example-kernels/runner-test/Cargo.toml
@@ -11,6 +11,7 @@ harness = false
 [dependencies]
 bootloader = "0.9.7"
 x86_64 = "0.11.0"
+rlibc = "1.0.0"
 
 [package.metadata.bootimage]
 test-success-exit-code = 33 # (0x10 << 1) | 1

--- a/example-kernels/runner-test/Cargo.toml
+++ b/example-kernels/runner-test/Cargo.toml
@@ -9,7 +9,7 @@ name = "no-harness"
 harness = false
 
 [dependencies]
-bootloader = "0.9.3"
+bootloader = "0.9.7"
 x86_64 = "0.11.0"
 
 [package.metadata.bootimage]

--- a/example-kernels/runner-test/src/lib.rs
+++ b/example-kernels/runner-test/src/lib.rs
@@ -5,6 +5,8 @@
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
+extern crate rlibc;
+
 pub fn test_runner(tests: &[&dyn Fn()]) {
     for test in tests.iter() {
         test();

--- a/example-kernels/runner/Cargo.toml
+++ b/example-kernels/runner/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = "0.9.3"
+bootloader = "0.9.7"
 x86_64 = "0.11.0"
 
 [package.metadata.bootimage]

--- a/src/bin/cargo-bootimage.rs
+++ b/src/bin/cargo-bootimage.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use bootimage::{
     args::{BuildArgs, BuildCommand},
     builder::Builder,
-    help,
+    config, help,
 };
 use std::{
     env,
@@ -43,9 +43,10 @@ pub fn main() -> Result<()> {
 
 fn build(args: BuildArgs) -> Result<()> {
     let mut builder = Builder::new(args.manifest_path().map(PathBuf::from))?;
+    let config = config::read_config(builder.manifest_path())?;
     let quiet = args.quiet();
 
-    let executables = builder.build_kernel(&args.cargo_args(), quiet)?;
+    let executables = builder.build_kernel(&args.cargo_args(), &config, quiet)?;
     if executables.is_empty() {
         return Err(anyhow!("no executables built"));
     }

--- a/src/builder/error.rs
+++ b/src/builder/error.rs
@@ -29,19 +29,19 @@ pub enum BuildKernelError {
     )]
     XbuildNotFound,
 
-    /// Running `cargo xbuild` failed.
+    /// Running `cargo build` failed.
     #[error("Kernel build failed.\nStderr: {}", String::from_utf8_lossy(.stderr))]
-    XbuildFailed {
+    BuildFailed {
         /// The standard error output.
         stderr: Vec<u8>,
     },
 
-    /// The output of `cargo xbuild --message-format=json` was not valid UTF-8
+    /// The output of `cargo build --message-format=json` was not valid UTF-8
     #[error("Output of kernel build with --message-format=json is not valid UTF-8:\n{0}")]
-    XbuildJsonOutputInvalidUtf8(std::string::FromUtf8Error),
-    /// The output of `cargo xbuild --message-format=json` was not valid JSON
+    BuildJsonOutputInvalidUtf8(std::string::FromUtf8Error),
+    /// The output of `cargo build --message-format=json` was not valid JSON
     #[error("Output of kernel build with --message-format=json is not valid JSON:\n{0}")]
-    XbuildJsonOutputInvalidJson(json::Error),
+    BuildJsonOutputInvalidJson(json::Error),
 }
 
 /// Represents an error that occurred when creating a bootimage.
@@ -59,7 +59,7 @@ pub enum CreateBootimageError {
     /// Building the bootloader failed
     #[error("Bootloader build failed.\nStderr: {}", String::from_utf8_lossy(.stderr))]
     BootloaderBuildFailed {
-        /// The `cargo xbuild` output to standard error
+        /// The `cargo build` output to standard error
         stderr: Vec<u8>,
     },
 
@@ -76,12 +76,12 @@ pub enum CreateBootimageError {
         error: io::Error,
     },
 
-    /// The output of `cargo xbuild --message-format=json` was not valid UTF-8
+    /// The output of `cargo build --message-format=json` was not valid UTF-8
     #[error("Output of bootloader build with --message-format=json is not valid UTF-8:\n{0}")]
-    XbuildJsonOutputInvalidUtf8(std::string::FromUtf8Error),
-    /// The output of `cargo xbuild --message-format=json` was not valid JSON
+    BuildJsonOutputInvalidUtf8(std::string::FromUtf8Error),
+    /// The output of `cargo build --message-format=json` was not valid JSON
     #[error("Output of bootloader build with --message-format=json is not valid JSON:\n{0}")]
-    XbuildJsonOutputInvalidJson(json::Error),
+    BuildJsonOutputInvalidJson(json::Error),
 }
 
 /// There is something wrong with the bootloader dependency.

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,7 +128,7 @@ struct ConfigBuilder {
 impl Into<Config> for ConfigBuilder {
     fn into(self) -> Config {
         Config {
-            build_command: self.build_command.unwrap_or(vec!["build".into()]),
+            build_command: self.build_command.unwrap_or_else(|| vec!["build".into()]),
             run_command: self.run_command.unwrap_or_else(|| {
                 vec![
                     "qemu-system-x86_64".into(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,34 +76,13 @@ fn read_config_inner(manifest_path: &Path) -> Result<Config> {
                 config.test_success_exit_code = Some(exit_code as i32);
             }
             ("run-command", Value::Array(array)) => {
-                let mut command = Vec::new();
-                for value in array {
-                    match value {
-                        Value::String(s) => command.push(s),
-                        _ => return Err(anyhow!("run-command must be a list of strings")),
-                    }
-                }
-                config.run_command = Some(command);
+                config.run_command = Some(parse_string_array(array, "run-command")?);
             }
             ("run-args", Value::Array(array)) => {
-                let mut args = Vec::new();
-                for value in array {
-                    match value {
-                        Value::String(s) => args.push(s),
-                        _ => return Err(anyhow!("run-args must be a list of strings")),
-                    }
-                }
-                config.run_args = Some(args);
+                config.run_args = Some(parse_string_array(array, "run-args")?);
             }
             ("test-args", Value::Array(array)) => {
-                let mut args = Vec::new();
-                for value in array {
-                    match value {
-                        Value::String(s) => args.push(s),
-                        _ => return Err(anyhow!("test-args must be a list of strings")),
-                    }
-                }
-                config.test_args = Some(args);
+                config.test_args = Some(parse_string_array(array, "test-args")?);
             }
             (key, value) => {
                 return Err(anyhow!(
@@ -116,6 +95,17 @@ fn read_config_inner(manifest_path: &Path) -> Result<Config> {
         }
     }
     Ok(config.into())
+}
+
+fn parse_string_array(array: Vec<Value>, prop_name: &str) -> Result<Vec<String>> {
+    let mut parsed = Vec::new();
+    for value in array {
+        match value {
+            Value::String(s) => parsed.push(s),
+            _ => return Err(anyhow!("{} must be a list of strings", prop_name)),
+        }
+    }
+    Ok(parsed)
 }
 
 #[derive(Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,9 +12,9 @@ use toml::Value;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Config {
-    /// The command that is used for building the kernel for `cargo bootimage`.
+    /// The cargo subcommand that is used for building the kernel for `cargo bootimage`.
     ///
-    /// Defaults to `cargo build`.
+    /// Defaults to `build`.
     pub build_command: Vec<String>,
     /// The run command that is invoked on `bootimage run` or `bootimage runner`
     ///
@@ -128,9 +128,7 @@ struct ConfigBuilder {
 impl Into<Config> for ConfigBuilder {
     fn into(self) -> Config {
         Config {
-            build_command: self
-                .build_command
-                .unwrap_or(vec!["cargo".into(), "build".into()]),
+            build_command: self.build_command.unwrap_or(vec!["build".into()]),
             run_command: self.run_command.unwrap_or_else(|| {
                 vec![
                     "qemu-system-x86_64".into(),

--- a/src/help/cargo_bootimage_help.txt
+++ b/src/help/cargo_bootimage_help.txt
@@ -11,3 +11,13 @@ BUILD_OPTS:
     is downloaded and built, and then combined with the kernel into a bootable
     disk image.
 
+CONFIGURATION:
+    The behavior of `cargo bootimage` can be configured through a
+    `[package.metadata.bootimage]` table in the `Cargo.toml`. The
+    following options are available to configure the build behavior:
+
+    [package.metadata.bootimage]
+    # The cargo subcommand that will be used for building the kernel.
+    #
+    # For building using the `cargo-xbuild` crate, set this to `xbuild`.
+    build-command = ["build"]


### PR DESCRIPTION
This updates the `cargo bootimage` command to build the kernel using a normal `cargo build` instead of `cargo xbuild` by default. This makes it possible to create kernels that don't depend on the `cargo-xbuild` crate anymore.

The cargo subcommand that is used for the kernel build can be adjusted by a new `package.metadata.bootimage.build-command` configuration key, which is set to `["build"]`. By setting it to `["xbuild"]`, it is possible to make the kernel build use the `cargo-xbuild` crate again. It is also possible to pass additional build arguments. 

This is a **breaking change**.