### PR TITLE
Parse `--version` argument without subcommand (`bootimage --version`)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,10 @@ pub fn main() -> Result<()> {
             help::print_help();
             return Ok(())
         }
+        Some("--version") => {
+            help::print_version();
+            return Ok(())
+        }
         Some(other) => return Err(anyhow!(
             "Unsupported subcommand `{:?}`. See `bootimage --help` for an overview of supported subcommands.", other
         )),


### PR DESCRIPTION
Fixes #66﻿
