### PR TITLE
Fix nightly breakage of doctests in workspaces

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix nightly breakage of doctests in workspaces ([#69](https://github.com/rust-osdev/bootimage/pull/69))
+
 # 0.10.1 – 2020-08-03
 
 - Parse `--version` argument without subcommand (`bootimage --version`) ([#67](https://github.com/rust-osdev/bootimage/pull/67))


### PR DESCRIPTION
In rust-lang/cargo#8954 the working directory for the runner executable changed for doctests. Before, the working directory was the crate dir, now it is the workspace dir. This lead to a bug in bootimage because it now looked for the `test-args` and other config option in the workpace root `Cargo.toml`, instead of the crate-specific `Cargo.toml`.

This commit fixes this by using the `CARGO_MANIFEST_DIR` environment variable for determining the `Cargo.toml` path, instead of directly using `cargo locate-project` as before.