### PR TITLE
Updated dependency version

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ First you need to add a dependency on the [`bootloader`](https://github.com/rust
 # in your Cargo.toml
 
 [dependencies]
-bootloader = "0.6.4"
+bootloader = "0.9.8"
 ```
 
 **Note**: At least bootloader version `0.5.1` is required since `bootimage 0.7.0`. For earlier bootloader versions, use `bootimage 0.6.6`.


### PR DESCRIPTION
Updated `bootloader` dependency version, matching the blog post https://os.phil-opp.com/minimal-rust-kernel/#printing-to-screen

The old version threw the following error
```sh
--> /home/[redacted]/.cargo/registry/src/github.com-[numbers]/x86_64-0.7.7/src/registers/rflags.rs:79:18
|
|         unsafe { asm!("pushfq; popq $0" : "=r"(r) :: "memory") };
|                  ----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
|                  |
|                  help: replace with: `llvm_asm!`
|
= note: consider migrating to the new asm! syntax specified in RFC 2873
= note: alternatively, switch to llvm_asm! to keep your code working as it is
```