### PR TITLE
Added support for target-specific config metadata

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -87,6 +87,10 @@ test-timeout = 300
 test-no-reboot = true
 ```
 
+## Target-specific configuration
+
+Target-specific configuration can be done through `[package.metadata.<target-triple>.bootimage]`. The default architecture if none is specified is `x86_64`.
+
 ## License
 
 Licensed under either of

--- a/src/builder/error.rs
+++ b/src/builder/error.rs
@@ -133,6 +133,13 @@ pub enum DiskImageError {
     #[error("Could not find `llvm-objcopy` in the `llvm-tools-preview` rustup component.")]
     LlvmObjcopyNotFound,
 
+    /// The build target is not supported
+    #[error("The specified build target '{target}' is not supported. Supported architectures are: x86_64, aarch64")]
+    TargetNotSupported {
+        /// The specified build target (from env:TARGET)
+        target: String
+    },
+
     /// The `llvm-objcopy` command failed
     #[error("Failed to run `llvm-objcopy`: {}", String::from_utf8_lossy(.stderr))]
     ObjcopyFailed {


### PR DESCRIPTION
Just a quick little change to allow bootimage to work with aarch64. I haven't been able to actually _test_ it because I don't have a working aarch64-compatible bootloader (im using `bootloader` which is x86 only). Really I was just experimenting to see how much work it would be to add a raspi target to my toy OS, which I don't think I'm going to follow through with. I do know default x86_64 behavior still works as expected. Merge the changes if you like, reject them if you don't, I don't mind either way. Just figured I'd share it in case it's useful.