### PR TITLE
enable popcnt cpu feature by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -142,6 +142,8 @@ impl Into<Config> for ConfigBuilder {
                     "qemu-system-x86_64".into(),
                     "-drive".into(),
                     "format=raw,file={}".into(),
+                    "-cpu".into(),
+                    "qemu64,+popcnt".into(),
                 ]
             }),
             run_args: self.run_args,


### PR DESCRIPTION
Rust on x86_64 by default can emit `popcnt` instructions. Since this instruction is widely supported by modern hardware, we should enable it too.
Related to phil-opp/blog_os/issues/1301.
Rust's `core::ptr::write_volatile()` on debug mode emits code with debug assertions, which use `popcnt`, leading to an cpu exception.
This fixes the issue for me, but I can't guarantee it's a universal fix.