### PR TITLE
Fix bootloader build by passing `-Zjson-target-spec`

### DIFF
--- a/src/builder/bootloader.rs
+++ b/src/builder/bootloader.rs
@@ -124,6 +124,7 @@ impl BuildConfig {
         cmd.arg("--features")
             .arg(self.features.as_slice().join(" "));
         cmd.arg("--target").arg(&self.target);
+        cmd.arg("-Zjson-target-spec");
         cmd.arg("--release");
         cmd.env("KERNEL", &self.kernel_bin_path);
         cmd.env("KERNEL_MANIFEST", &self.kernel_manifest_path);


### PR DESCRIPTION
Required on latest nightlies

This fix is mostly needed when the kernel uses the built-in x86_64-unknown-none target. Otherwise the user probably already has enabled the `json-target-spec` feature through a `.cargo/config.toml` file, which then also applies to the bootloader build.
